### PR TITLE
[#5] Ticket: Add category and external issue link

### DIFF
--- a/doc/entity-diagram.md
+++ b/doc/entity-diagram.md
@@ -57,6 +57,8 @@ erDiagram
         BIGINT company_id FK
         BIGINT requester_id FK
         BIGINT company_entitlement_id FK
+        BIGINT category_id FK
+        STRING external_issue_link
     }
 
     MESSAGE {
@@ -94,6 +96,12 @@ erDiagram
         STRING normal_color
     }
 
+    CATEGORY {
+        BIGINT id PK
+        STRING name
+        BOOLEAN is_default
+    }
+
     COMPANY_ENTITLEMENT {
         BIGINT id PK
         BIGINT company_id FK
@@ -118,4 +126,5 @@ erDiagram
     ENTITLEMENT ||--o{ COMPANY_ENTITLEMENT : includes
     SUPPORT_LEVEL ||--o{ COMPANY_ENTITLEMENT : levels
     COMPANY_ENTITLEMENT ||--o{ TICKET : applies
+    CATEGORY ||--o{ TICKET : categorizes
 ```

--- a/src/main/java/ai/mnemosyne_systems/model/Category.java
+++ b/src/main/java/ai/mnemosyne_systems/model/Category.java
@@ -1,0 +1,38 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "categories")
+public class Category extends PanacheEntityBase {
+
+    @Id
+    @SequenceGenerator(name = "category_seq", sequenceName = "category_seq", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "category_seq")
+    public Long id;
+
+    @Column(nullable = false)
+    public String name;
+
+    @Column(name = "is_default", nullable = false)
+    public boolean isDefault;
+
+    public static Category findDefault() {
+        return find("isDefault", true).firstResult();
+    }
+}

--- a/src/main/java/ai/mnemosyne_systems/model/Ticket.java
+++ b/src/main/java/ai/mnemosyne_systems/model/Ticket.java
@@ -40,6 +40,13 @@ public class Ticket extends PanacheEntityBase {
     @Column(nullable = false)
     public String status;
 
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    public Category category;
+
+    @Column(name = "external_issue_link")
+    public String externalIssueLink;
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "company_id", nullable = false)
     public Company company;

--- a/src/main/java/ai/mnemosyne_systems/web/CategoryResource.java
+++ b/src/main/java/ai/mnemosyne_systems/web/CategoryResource.java
@@ -1,0 +1,141 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.web;
+
+import ai.mnemosyne_systems.model.Category;
+import ai.mnemosyne_systems.model.User;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.List;
+
+@Path("/categories")
+@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+@Produces(MediaType.TEXT_HTML)
+@Blocking
+public class CategoryResource {
+
+    @Location("category/categories.html")
+    Template categoriesTemplate;
+
+    @Location("category/category-form.html")
+    Template categoryFormTemplate;
+
+    @GET
+    public TemplateInstance list(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
+        User user = requireAdmin(auth);
+        List<Category> categories = Category.listAll();
+        return categoriesTemplate.data("categories", categories).data("currentUser", user);
+    }
+
+    @GET
+    @Path("/create")
+    public TemplateInstance createForm(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
+        User user = requireAdmin(auth);
+        return categoryFormTemplate.data("category", new Category()).data("action", "/categories")
+                .data("title", "New Category").data("currentUser", user);
+    }
+
+    @GET
+    @Path("/{id}/edit")
+    public TemplateInstance editForm(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+        User user = requireAdmin(auth);
+        Category category = Category.findById(id);
+        if (category == null) {
+            throw new NotFoundException();
+        }
+        return categoryFormTemplate.data("category", category).data("action", "/categories/" + id)
+                .data("title", "Edit Category").data("currentUser", user);
+    }
+
+    @POST
+    @Transactional
+    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @FormParam("name") String name,
+            @FormParam("isDefault") String isDefault) {
+        requireAdmin(auth);
+        if (name == null || name.isBlank()) {
+            throw new BadRequestException("Name is required");
+        }
+        boolean makeDefault = "true".equalsIgnoreCase(isDefault);
+        if (makeDefault) {
+            clearDefaults();
+        }
+        Category category = new Category();
+        category.name = name.trim();
+        category.isDefault = makeDefault;
+        category.persist();
+        return Response.seeOther(URI.create("/categories")).build();
+    }
+
+    @POST
+    @Path("/{id}")
+    @Transactional
+    public Response update(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
+            @FormParam("name") String name, @FormParam("isDefault") String isDefault) {
+        requireAdmin(auth);
+        Category category = Category.findById(id);
+        if (category == null) {
+            throw new NotFoundException();
+        }
+        if (name == null || name.isBlank()) {
+            throw new BadRequestException("Name is required");
+        }
+        boolean makeDefault = "true".equalsIgnoreCase(isDefault);
+        if (makeDefault) {
+            clearDefaults();
+        }
+        category.name = name.trim();
+        category.isDefault = makeDefault;
+        return Response.seeOther(URI.create("/categories")).build();
+    }
+
+    @POST
+    @Path("/{id}/delete")
+    @Transactional
+    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+        requireAdmin(auth);
+        Category category = Category.findById(id);
+        if (category == null) {
+            throw new NotFoundException();
+        }
+        category.delete();
+        return Response.seeOther(URI.create("/categories")).build();
+    }
+
+    private void clearDefaults() {
+        List<Category> defaults = Category.list("isDefault", true);
+        for (Category existing : defaults) {
+            existing.isDefault = false;
+        }
+    }
+
+    private User requireAdmin(String auth) {
+        User user = AuthHelper.findUser(auth);
+        if (!AuthHelper.isAdmin(user)) {
+            throw new WebApplicationException(Response.seeOther(URI.create("/")).build());
+        }
+        return user;
+    }
+}

--- a/src/main/java/ai/mnemosyne_systems/web/UserSeeder.java
+++ b/src/main/java/ai/mnemosyne_systems/web/UserSeeder.java
@@ -8,6 +8,7 @@
 
 package ai.mnemosyne_systems.web;
 
+import ai.mnemosyne_systems.model.Category;
 import ai.mnemosyne_systems.model.Attachment;
 import ai.mnemosyne_systems.model.Company;
 import ai.mnemosyne_systems.model.Country;
@@ -201,6 +202,10 @@ public class UserSeeder {
         seedSupportLevel("Low", "Standard response window", 60, "Red", 720, "Yellow", 1440, "White");
         seedSupportLevel("Normal", "Default response window", 60, "Red", 120, "Yellow", 720, "White");
         seedSupportLevel("High", "Escalated response window", 60, "Red", 90, "Yellow", 120, "White");
+
+        seedCategory("Feature", false);
+        seedCategory("Bug", false);
+        seedCategory("Question", true);
     }
 
     private Country findCountryByCode(String code) {
@@ -281,7 +286,11 @@ public class UserSeeder {
             ticket.company = company;
             ticket.requester = requester;
             ticket.companyEntitlement = entitlement;
+            ticket.category = Category.findDefault();
             ticket.persist();
+        }
+        if (ticket.category == null) {
+            ticket.category = Category.findDefault();
         }
         if (ticket.status == null || ticket.status.isBlank()) {
             ticket.status = "Open";
@@ -417,6 +426,17 @@ public class UserSeeder {
         level.normal = normal;
         level.normalColor = normalColor;
         level.persist();
+    }
+
+    private void seedCategory(String name, boolean isDefault) {
+        Category category = Category.find("name", name).firstResult();
+        if (category != null) {
+            return;
+        }
+        category = new Category();
+        category.name = name;
+        category.isDefault = isDefault;
+        category.persist();
     }
 
     private void removeUser(String email) {

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -284,3 +284,10 @@ VALUES (nextval('support_level_seq'), 'Normal', 'Default response window', 60, '
 
 INSERT INTO support_levels (id, name, description, critical, critical_color, escalate, escalate_color, normal, normal_color)
 VALUES (nextval('support_level_seq'), 'High', 'Escalated response window', 60, 'Red', 90, 'Yellow', 120, 'White');
+
+-- =====================
+-- CATEGORIES
+-- =====================
+INSERT INTO categories (id, name, is_default) VALUES (nextval('category_seq'), 'Feature', false);
+INSERT INTO categories (id, name, is_default) VALUES (nextval('category_seq'), 'Bug', false);
+INSERT INTO categories (id, name, is_default) VALUES (nextval('category_seq'), 'Question', true);

--- a/src/main/resources/templates/admin-layout.html
+++ b/src/main/resources/templates/admin-layout.html
@@ -293,6 +293,7 @@
             <a href="/users">Users</a>
             <a href="/entitlements">Entitlements</a>
             <a href="/support-levels">Support Levels</a>
+            <a href="/categories">Categories</a>
         </nav>
     </div>
     <div class="header-actions">

--- a/src/main/resources/templates/category/categories.html
+++ b/src/main/resources/templates/category/categories.html
@@ -1,0 +1,40 @@
+<!--
+  Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+-->
+
+{#include admin-layout}
+    {#content}
+        <div class="support-header">
+            <h1>Categories</h1>
+            <a class="action-button" href="/categories/create">Create</a>
+        </div>
+        <table>
+            <thead>
+            <tr>
+                <th>Name <button class="sort-button" type="button" onclick="sortTable(this, 0)">↕</button></th>
+                <th>Default <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            {#for cat in categories}
+                <tr>
+                    <td><a href="/categories/{cat.id}/edit">{cat.name}</a></td>
+                    <td>{#if cat.isDefault}Yes{#else}No{/if}</td>
+                    <td>
+                        <form class="inline" method="post" action="/categories/{cat.id}/delete">
+                            <button type="submit" class="icon-button" title="Delete">
+                                <svg viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6M10 10v8M14 10v8"/></svg>
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+            {/for}
+            </tbody>
+        </table>
+    {/content}
+{/include}

--- a/src/main/resources/templates/category/category-form.html
+++ b/src/main/resources/templates/category/category-form.html
@@ -1,0 +1,33 @@
+<!--
+  Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+-->
+
+{#include admin-layout}
+    {#content}
+        <div class="form-card">
+            <h1>{title}</h1>
+            <form method="post" action="{action}">
+                <div>
+                    <label>Name
+                        <input type="text" name="name" value="{#if category.name != null}{category.name}{/if}" required>
+                    </label>
+                </div>
+                <div>
+                    <label>Default
+                        <select name="isDefault">
+                            <option value="false" {#if !category.isDefault}selected{/if}>No</option>
+                            <option value="true" {#if category.isDefault}selected{/if}>Yes</option>
+                        </select>
+                    </label>
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="action-button">Save</button>
+                </div>
+            </form>
+        </div>
+    {/content}
+{/include}

--- a/src/main/resources/templates/support/support-ticket-table.html
+++ b/src/main/resources/templates/support/support-ticket-table.html
@@ -12,10 +12,11 @@
         <th>Name <button class="sort-button" type="button" onclick="sortTable(this, 0)">↕</button></th>
         <th>Date <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
         <th>Status <button class="sort-button" type="button" onclick="sortTable(this, 2)">↕</button></th>
-        <th>Support <button class="sort-button" type="button" onclick="sortTable(this, 3)">↕</button></th>
-        <th>Company <button class="sort-button" type="button" onclick="sortTable(this, 4)">↕</button></th>
-        <th>Entitlement <button class="sort-button" type="button" onclick="sortTable(this, 5)">↕</button></th>
-        <th>Service level <button class="sort-button" type="button" onclick="sortTable(this, 6)">↕</button></th>
+        <th>Category <button class="sort-button" type="button" onclick="sortTable(this, 3)">↕</button></th>
+        <th>Support <button class="sort-button" type="button" onclick="sortTable(this, 4)">↕</button></th>
+        <th>Company <button class="sort-button" type="button" onclick="sortTable(this, 5)">↕</button></th>
+        <th>Entitlement <button class="sort-button" type="button" onclick="sortTable(this, 6)">↕</button></th>
+        <th>Service level <button class="sort-button" type="button" onclick="sortTable(this, 7)">↕</button></th>
     </tr>
     </thead>
     <tbody>
@@ -24,6 +25,7 @@
         <td style="{#if slaColors.containsKey(ticket.id)}background-color: {slaColors.get(ticket.id)}{/if}"><a href="/tickets/{ticket.id}">{ticket.name}</a></td>
         <td style="{#if slaColors.containsKey(ticket.id)}background-color: {slaColors.get(ticket.id)}{/if}">{messageDateLabels.get(ticket.id)}</td>
         <td style="{#if slaColors.containsKey(ticket.id)}background-color: {slaColors.get(ticket.id)}{/if}">{ticket.status}</td>
+        <td>{#if ticket.category != null}{ticket.category.name}{#else}-{/if}</td>
         <td>
             {#if supportAssignmentIds.containsKey(ticket.id)}
             <a href="/support/support-users/{supportAssignmentIds.get(ticket.id)}">{supportAssignmentNames.get(ticket.id)}</a>

--- a/src/main/resources/templates/support/ticket-detail.html
+++ b/src/main/resources/templates/support/ticket-detail.html
@@ -18,17 +18,15 @@
             <label>Company
                 <input type="text" value="{ticket.company.name}" readonly>
             </label>
-            <label>Status
+            <label>Category
                 {#if editableStatus?? && editableStatus}
-                <select name="status" required>
-                    <option value="Open" {#if displayStatus == 'Open'}selected{/if}>Open</option>
-                    <option value="Assigned" {#if displayStatus == 'Assigned'}selected{/if}>Assigned</option>
-                    <option value="In Progress" {#if displayStatus == 'In Progress'}selected{/if}>In Progress</option>
-                    <option value="Resolved" {#if displayStatus == 'Resolved'}selected{/if}>Resolved</option>
-                    <option value="Closed" {#if displayStatus == 'Closed'}selected{/if}>Closed</option>
+                <select name="categoryId">
+                    {#for cat in categories}
+                        <option value="{cat.id}" {#if ticket.category != null && ticket.category.id == cat.id}selected{/if}>{cat.name}</option>
+                    {/for}
                 </select>
                 {#else}
-                <input type="text" value="{displayStatus}" readonly>
+                    <input type="text" value="{#if ticket.category != null}{ticket.category.name}{#else}-{/if}" readonly>
                 {/if}
             </label>
             <label>Entitlement
@@ -38,15 +36,17 @@
                 <input type="text" value="{ticket.companyEntitlement.entitlement.name}" readonly>
                 {/if}
             </label>
-            <label>Support users
-                {#if supportUsers.isEmpty}
-                <input type="text" value="-" readonly>
+            <label>Status
+                {#if editableStatus?? && editableStatus}
+                    <select name="status" required>
+                        <option value="Open" {#if displayStatus == 'Open'}selected{/if}>Open</option>
+                        <option value="Assigned" {#if displayStatus == 'Assigned'}selected{/if}>Assigned</option>
+                        <option value="In Progress" {#if displayStatus == 'In Progress'}selected{/if}>In Progress</option>
+                        <option value="Resolved" {#if displayStatus == 'Resolved'}selected{/if}>Resolved</option>
+                        <option value="Closed" {#if displayStatus == 'Closed'}selected{/if}>Closed</option>
+                    </select>
                 {#else}
-                <div>
-                    {#for user in supportUsers}
-                    <a href="{supportUserBase}/{user.id}">{user.name}</a>{#if !user_isLast}, {/if}
-                    {/for}
-                </div>
+                    <input type="text" value="{displayStatus}" readonly>
                 {/if}
             </label>
             <label>Service Level
@@ -56,8 +56,16 @@
                 <input type="text" value="{ticket.companyEntitlement.supportLevel.name}" readonly>
                 {/if}
             </label>
-            <label class="ticket-detail-spacer" aria-hidden="true">
-                <input type="text" value="-" readonly>
+            <label>External issue
+                {#if editableStatus?? && editableStatus}
+                    <input type="text" name="externalIssueLink" value="{#if ticket.externalIssueLink != null}{ticket.externalIssueLink}{/if}">
+                {#else}
+                    {#if ticket.externalIssueLink != null && !ticket.externalIssueLink.isBlank}
+                        <a href="{ticket.externalIssueLink}" target="_blank" rel="noopener">{ticket.externalIssueLink}</a>
+                    {#else}
+                        <input type="text" value="-" readonly>
+                    {/if}
+                {/if}
             </label>
             <label>TAMs
                 {#if tamUsers.isEmpty}
@@ -69,6 +77,20 @@
                     {/for}
                 </div>
                 {/if}
+            </label>
+            <label>Support users
+                {#if supportUsers.isEmpty}
+                    <input type="text" value="-" readonly>
+                {#else}
+                    <div>
+                        {#for user in supportUsers}
+                            <a href="{supportUserBase}/{user.id}">{user.name}</a>{#if !user_isLast}, {/if}
+                        {/for}
+                    </div>
+                {/if}
+            </label>
+            <label class="ticket-detail-spacer" aria-hidden="true">
+                <input type="text" value="-" readonly>
             </label>
         </div>
         {#if editableStatus?? && editableStatus}

--- a/src/main/resources/templates/support/ticket-form.html
+++ b/src/main/resources/templates/support/ticket-form.html
@@ -16,6 +16,15 @@
                 <input type="text" name="ticketName" value="{#if ticketName??}{ticketName}{#else}{ticket.name}{/if}" readonly>
             </label>
         </div>
+        <div>
+            <label>Category
+                <select name="categoryId">
+                    {#for cat in categories}
+                        <option value="{cat.id}" {#if defaultCategoryId != null && defaultCategoryId == cat.id}selected{/if}>{cat.name}</option>
+                    {/for}
+                </select>
+            </label>
+        </div>
         <input type="hidden" name="status" value="Open">
         <div>
             <label class="markdown-label" for="support-ticket-message">Message</label>

--- a/src/main/resources/templates/tickets/form.html
+++ b/src/main/resources/templates/tickets/form.html
@@ -17,6 +17,15 @@
                 </label>
             </div>
             <div>
+                <label>Category
+                    <select name="categoryId">
+                        {#for cat in categories}
+                            <option value="{cat.id}" {#if ticket.category != null && ticket.category.id == cat.id}selected{/if}>{cat.name}</option>
+                        {/for}
+                    </select>
+                </label>
+            </div>
+            <div>
                 <label>Status
                     <select name="status" required>
                         <option value="Open" {#if ticket.status == 'Open'}selected{/if}>Open</option>
@@ -49,6 +58,11 @@
                     {#else}
                     <input type="text" value="{ticket.companyEntitlement.supportLevel.name}" readonly>
                     {/if}
+                </label>
+            </div>
+            <div>
+                <label>External issue
+                    <input type="text" name="externalIssueLink" value="{#if ticket.externalIssueLink != null}{ticket.externalIssueLink}{/if}">
                 </label>
             </div>
             <input type="hidden" name="companyId" value="{ticket.company.id}">

--- a/src/main/resources/templates/user/ticket-create.html
+++ b/src/main/resources/templates/user/ticket-create.html
@@ -16,6 +16,15 @@
                 <input type="text" name="ticketName" value="{#if ticketName??}{ticketName}{/if}" readonly>
             </label>
         </div>
+        <div>
+            <label>Category
+                <select name="categoryId">
+                    {#for cat in categories}
+                        <option value="{cat.id}" {#if defaultCategoryId != null && defaultCategoryId == cat.id}selected{/if}>{cat.name}</option>
+                    {/for}
+                </select>
+            </label>
+        </div>
         <input type="hidden" name="status" value="Open">
         <div>
             <label class="markdown-label" for="user-ticket-message">Message</label>


### PR DESCRIPTION
### New Things
- `Category` entity (id, name, is_default)
- `Ticket`: added `category` (ManyToOne -> Category) and `externalIssueLink` fields

### Relationship
- Category 1 --- n Ticket

### Seed data
- Preloaded categories: Feature, Bug, Question (default)

### UI
- Category dropdown on ticket creation forms (support + user)
- Category dropdown + external issue link on ticket detail (editable by support, read-only for user/TAM)
- Category column added to ticket list table
- Default category ("Question") applied when none selected

### Tests
- [x] Category column visible in ticket list
- [x] Category dropdown visible on create form with default "Question"
- [x] Category and external issue link visible on ticket detail
- [x] Default category applied on ticket creation
- [x] Category and external issue link updated on ticket update

Closes #5
