### PR TITLE
[#29] Remove Actions columns

### DIFF
--- a/src/main/resources/templates/category/categories.html
+++ b/src/main/resources/templates/category/categories.html
@@ -17,21 +17,13 @@
             <tr>
                 <th>Name <button class="sort-button" type="button" onclick="sortTable(this, 0)">↕</button></th>
                 <th>Default <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
-                <th>Actions</th>
             </tr>
             </thead>
             <tbody>
             {#for cat in categories}
                 <tr>
-                    <td><a href="/categories/{cat.id}/edit">{cat.name}</a></td>
+                    <td>{cat.name}</td>
                     <td>{#if cat.isDefault}Yes{#else}No{/if}</td>
-                    <td>
-                        <form class="inline" method="post" action="/categories/{cat.id}/delete">
-                            <button type="submit" class="icon-button" title="Delete">
-                                <svg viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6M10 10v8M14 10v8"/></svg>
-                            </button>
-                        </form>
-                    </td>
                 </tr>
             {/for}
             </tbody>

--- a/src/main/resources/templates/companies/list.html
+++ b/src/main/resources/templates/companies/list.html
@@ -22,7 +22,6 @@
         <th>State <button class="sort-button" type="button" onclick="sortTable(this, 6)">↕</button></th>
         <th>Zip <button class="sort-button" type="button" onclick="sortTable(this, 7)">↕</button></th>
         <th>Country <button class="sort-button" type="button" onclick="sortTable(this, 8)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 9)">↕</button></th>
     </tr>
     </thead>
     <tbody>
@@ -37,12 +36,6 @@
         <td>{company.state}</td>
         <td>{company.zip}</td>
         <td>{#if company.country}{company.country.name}{/if}</td>
-        <td data-sort-value="{company.id}">
-            <a href="/companies/{company.id}/edit">Edit</a>
-            <form class="inline" method="post" action="/companies/{company.id}/delete">
-                <button type="submit">Delete</button>
-            </form>
-        </td>
     </tr>
     {/for}
     </tbody>

--- a/src/main/resources/templates/company/companies.html
+++ b/src/main/resources/templates/company/companies.html
@@ -17,7 +17,6 @@
     <tr>
         <th>Name <button class="sort-button" type="button" onclick="sortTable(this, 0)">↕</button></th>
         <th>Country <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 2)">↕</button></th>
     </tr>
     </thead>
     <tbody>
@@ -25,24 +24,6 @@
     <tr>
         <td><a href="/companies/{company.id}">{company.name}</a></td>
         <td>{#if company.country}{company.country.name}{/if}</td>
-        <td data-sort-value="{company.id}">
-            <a class="icon-link" href="/companies/{company.id}/edit" title="Edit" aria-label="Edit">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
-                    <path d="M14.06 4.94l3.75 3.75" />
-                </svg>
-            </a>
-            <form class="inline" method="post" action="/companies/{company.id}/delete">
-                <button class="icon-button" type="submit" title="Remove" aria-label="Remove">
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 6h18" />
-                        <path d="M8 6V4h8v2" />
-                        <path d="M7 6l1 14h8l1-14" />
-                        <path d="M10 10v8M14 10v8" />
-                    </svg>
-                </button>
-            </form>
-        </td>
     </tr>
     {/for}
     </tbody>

--- a/src/main/resources/templates/entitlement/entitlements.html
+++ b/src/main/resources/templates/entitlement/entitlements.html
@@ -17,7 +17,6 @@
     <tr>
         <th>Name <button class="sort-button" type="button" onclick="sortTable(this, 0)">↕</button></th>
         <th>Description <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 2)">↕</button></th>
     </tr>
     </thead>
     <tbody>
@@ -25,24 +24,6 @@
     <tr>
         <td>{entitlement.name}</td>
         <td>{entitlement.description}</td>
-        <td data-sort-value="{entitlement.id}">
-            <a class="icon-link" href="/entitlements/{entitlement.id}/edit" title="Edit" aria-label="Edit">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
-                    <path d="M14.06 4.94l3.75 3.75" />
-                </svg>
-            </a>
-            <form class="inline" method="post" action="/entitlements/{entitlement.id}/delete">
-                <button class="icon-button" type="submit" title="Remove" aria-label="Remove">
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 6h18" />
-                        <path d="M8 6V4h8v2" />
-                        <path d="M7 6l1 14h8l1-14" />
-                        <path d="M10 10v8M14 10v8" />
-                    </svg>
-                </button>
-            </form>
-        </td>
     </tr>
     {/for}
     </tbody>

--- a/src/main/resources/templates/messages/list.html
+++ b/src/main/resources/templates/messages/list.html
@@ -64,7 +64,6 @@
         <th>Date <button class="sort-button" type="button" onclick="sortTable(this, 2)">↕</button></th>
         <th>Ticket <button class="sort-button" type="button" onclick="sortTable(this, 3)">↕</button></th>
         <th>Author <button class="sort-button" type="button" onclick="sortTable(this, 4)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 5)">↕</button></th>
     </tr>
     </thead>
     <tbody>
@@ -77,16 +76,10 @@
         <td>{message.date}</td>
         <td>{message.ticket.name}</td>
         <td>{#if message.author != null}<a href="mailto:{message.author.email}">{message.author.email}</a>{#else}-{/if}</td>
-        <td data-sort-value="{message.id}">
-            <a href="/messages/{message.id}/edit">Edit</a>
-            <form class="inline" method="post" action="/messages/{message.id}/delete">
-                <button type="submit">Delete</button>
-            </form>
-        </td>
     </tr>
     {#if !message.attachments.isEmpty}
     <tr class="message-attachments">
-        <td colspan="6">
+        <td colspan="5">
             {#for attachment in message.attachments}
             <div class="attachment-footer">
                 <span class="attachment-name">

--- a/src/main/resources/templates/support-level/support-levels.html
+++ b/src/main/resources/templates/support-level/support-levels.html
@@ -23,7 +23,6 @@
         <th>Escalate Color <button class="sort-button" type="button" onclick="sortTable(this, 5)">↕</button></th>
         <th>Normal <button class="sort-button" type="button" onclick="sortTable(this, 6)">↕</button></th>
         <th>Normal Color <button class="sort-button" type="button" onclick="sortTable(this, 7)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 8)">↕</button></th>
     </tr>
     </thead>
     <tbody>
@@ -37,24 +36,6 @@
         <td>{level.escalateColor}</td>
         <td>{level.normal}</td>
         <td>{level.normalColor}</td>
-        <td data-sort-value="{level.id}">
-            <a class="icon-link" href="/support-levels/{level.id}/edit" title="Edit" aria-label="Edit">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
-                    <path d="M14.06 4.94l3.75 3.75" />
-                </svg>
-            </a>
-            <form class="inline" method="post" action="/support-levels/{level.id}/delete">
-                <button class="icon-button" type="submit" title="Remove" aria-label="Remove">
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 6h18" />
-                        <path d="M8 6V4h8v2" />
-                        <path d="M7 6l1 14h8l1-14" />
-                        <path d="M10 10v8M14 10v8" />
-                    </svg>
-                </button>
-            </form>
-        </td>
     </tr>
     {/for}
     </tbody>

--- a/src/main/resources/templates/tickets/list.html
+++ b/src/main/resources/templates/tickets/list.html
@@ -18,14 +18,13 @@
         <th>Name <button class="sort-button" type="button" onclick="sortTable(this, 0)">↕</button></th>
         <th>Status <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
         <th>Company <button class="sort-button" type="button" onclick="sortTable(this, 2)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 3)">↕</button></th>
     </tr>
     </thead>
     <tbody>
     {#for ticket in tickets}
     <tr>
         <td>
-            <div><a href="/tickets/{ticket.id}/edit">{ticket.name}</a></div>
+            <div><a href="/tickets/{ticket.id}">{ticket.name}</a></div>
             {#for message in ticketMessages.get(ticket.id)}
             <div style="margin-top: 6px;">
                 <div><strong>{messageLabels.get(message.id)}</strong></div>
@@ -35,14 +34,6 @@
         </td>
         <td>{ticket.status}</td>
         <td>{ticket.company.name}</td>
-        <td data-sort-value="{ticket.id}">
-            <a class="icon-link" href="/tickets/{ticket.id}/edit" title="Edit" aria-label="Edit">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
-                    <path d="M14.06 4.94l3.75 3.75" />
-                </svg>
-            </a>
-        </td>
     </tr>
     {/for}
     </tbody>

--- a/src/main/resources/templates/user/users.html
+++ b/src/main/resources/templates/user/users.html
@@ -19,35 +19,15 @@
         <th>Email <button class="sort-button" type="button" onclick="sortTable(this, 1)">↕</button></th>
         <th>Social <button class="sort-button" type="button" onclick="sortTable(this, 2)">↕</button></th>
         <th>Type <button class="sort-button" type="button" onclick="sortTable(this, 3)">↕</button></th>
-        <th>Actions <button class="sort-button" type="button" onclick="sortTable(this, 4)">↕</button></th>
     </tr>
     </thead>
     <tbody>
     {#for user in users}
     <tr>
-        <td><a href="/users/{user.id}/edit">{user.name}</a></td>
-        {!<td><a href="/users/{user.id}">{user.name}</a></td>!}
+        <td><a href="/users/{user.id}">{user.name}</a></td>
         <td><a href="mailto:{user.email}">{user.email}</a></td>
         <td>{user.social ?: ''}</td>
         <td>{typeLabels.get(user.id)}</td>
-        <td data-sort-value="{user.id}">
-            <a class="icon-link" href="/users/{user.id}/edit" title="Edit" aria-label="Edit">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
-                    <path d="M14.06 4.94l3.75 3.75" />
-                </svg>
-            </a>
-            <form class="inline" method="post" action="/users/{user.id}/delete">
-                <button class="icon-button" type="submit" title="Remove" aria-label="Remove">
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 6h18" />
-                        <path d="M8 6V4h8v2" />
-                        <path d="M7 6l1 14h8l1-14" />
-                        <path d="M10 10v8M14 10v8" />
-                    </svg>
-                </button>
-            </form>
-        </td>
     </tr>
     {/for}
     </tbody>


### PR DESCRIPTION
Closes #29

### Changes made:
- Remove the `Actions` table columns from all pages.
- `Name` fields link to view pages where available, otherwise plain text.
- Names no longer link directly to edit forms. Edit access is through view pages based on role.
