### PR TITLE
[#62] Reports PDF export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.webjars.npm</groupId>
             <artifactId>chart.js</artifactId>
-            <version>4.4.7</version>
+            <version>4.5.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/ai/mnemosyne_systems/web/PdfService.java
+++ b/src/main/java/ai/mnemosyne_systems/web/PdfService.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 @ApplicationScoped
 public class PdfService {
@@ -110,6 +111,189 @@ public class PdfService {
             PdfPTable messagesTable = generateMessages(ticket.messages);
             document.add(messagesTable);
             document.add(Chunk.NEWLINE);
+            document.close();
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to generate PDF", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate PDF", e);
+        }
+    }
+
+    public byte[] generateReportPdf(ReportResource.ReportData data, String companyName, String period,
+            boolean showCompanyTable, Map<String, String> chartImages) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Document document = new Document();
+            PdfWriter.getInstance(document, outputStream);
+            document.open();
+
+            Font titleFont = FontFactory.getFont(FontFactory.COURIER_BOLD, 16);
+            Font sectionFont = FontFactory.getFont(FontFactory.COURIER_BOLD, 13);
+            Font normalFont = FontFactory.getFont(FontFactory.COURIER, 12);
+            Font subFont = FontFactory.getFont(FontFactory.COURIER, 10, Color.GRAY);
+
+            // Owner header
+            Installation installation = getOwner();
+            Font subHeaderFont = FontFactory.getFont(FontFactory.COURIER_BOLD, 14, Color.white);
+            Chunk ownerHeader = new Chunk(installation.name, subHeaderFont);
+            ownerHeader.setBackground(red, 5f, 5f, 400f, 5f);
+            Paragraph owner = new Paragraph(ownerHeader);
+            owner.setAlignment(Paragraph.ALIGN_LEFT);
+            document.add(owner);
+            document.add(Chunk.NEWLINE);
+
+            // Title
+            Paragraph title = new Paragraph("Report — " + companyName, titleFont);
+            title.setAlignment(Paragraph.ALIGN_CENTER);
+            document.add(title);
+            document.add(Chunk.NEWLINE);
+
+            // Summary line
+            Paragraph summary = new Paragraph("Total tickets: " + data.totalTickets, subFont);
+            summary.setAlignment(Paragraph.ALIGN_CENTER);
+            document.add(summary);
+            document.add(Chunk.NEWLINE);
+
+            // Tickets by Status
+            document.add(new Paragraph("Tickets by Status", sectionFont));
+            document.add(Chunk.NEWLINE);
+            addChartImage(document, chartImages, "statusChart");
+            PdfPTable statusTable = new PdfPTable(2);
+            statusTable.setWidthPercentage(100);
+            statusTable.addCell(createCell("Status", red, Color.WHITE));
+            statusTable.addCell(createCell("Count", red, Color.WHITE));
+            for (Map.Entry<String, Long> entry : data.ticketsByStatus.entrySet()) {
+                statusTable.addCell(new Phrase(entry.getKey(), normalFont));
+                statusTable.addCell(new Phrase(String.valueOf(entry.getValue()), normalFont));
+            }
+            document.add(statusTable);
+            document.add(Chunk.NEWLINE);
+
+            // Tickets by Category
+            document.add(new Paragraph("Tickets by Category", sectionFont));
+            document.add(Chunk.NEWLINE);
+            addChartImage(document, chartImages, "categoryChart");
+            PdfPTable categoryTable = new PdfPTable(2);
+            categoryTable.setWidthPercentage(100);
+            categoryTable.addCell(createCell("Category", red, Color.WHITE));
+            categoryTable.addCell(createCell("Count", red, Color.WHITE));
+            for (Map.Entry<String, Long> entry : data.ticketsByCategory.entrySet()) {
+                categoryTable.addCell(new Phrase(entry.getKey(), normalFont));
+                categoryTable.addCell(new Phrase(String.valueOf(entry.getValue()), normalFont));
+            }
+            document.add(categoryTable);
+            document.add(Chunk.NEWLINE);
+
+            // Tickets by Company
+            if (showCompanyTable) {
+                document.add(new Paragraph("Tickets by Company", sectionFont));
+                document.add(Chunk.NEWLINE);
+                addChartImage(document, chartImages, "companyChart");
+                PdfPTable companyTable = new PdfPTable(2);
+                companyTable.setWidthPercentage(100);
+                companyTable.addCell(createCell("Company", red, Color.WHITE));
+                companyTable.addCell(createCell("Count", red, Color.WHITE));
+                for (Map.Entry<String, Long> entry : data.ticketsByCompany.entrySet()) {
+                    companyTable.addCell(new Phrase(entry.getKey(), normalFont));
+                    companyTable.addCell(new Phrase(String.valueOf(entry.getValue()), normalFont));
+                }
+                document.add(companyTable);
+                document.add(Chunk.NEWLINE);
+            }
+
+            // Ticket Volume Over Time
+            String periodLabel = "year".equals(period) ? "This year"
+                    : "month".equals(period) ? "This month" : "All time";
+            document.add(new Paragraph("Ticket Volume Over Time — " + periodLabel, sectionFont));
+            document.add(Chunk.NEWLINE);
+            addChartImage(document, chartImages, "timeChart");
+            if (data.ticketsOverTime.isEmpty()) {
+                document.add(new Paragraph("No data available", normalFont));
+            } else {
+                PdfPTable timeTable = new PdfPTable(2);
+                timeTable.setWidthPercentage(100);
+                timeTable.addCell(createCell("Period", red, Color.WHITE));
+                timeTable.addCell(createCell("Tickets Created", red, Color.WHITE));
+                for (Map.Entry<String, Long> entry : data.ticketsOverTime.entrySet()) {
+                    timeTable.addCell(new Phrase(entry.getKey(), normalFont));
+                    timeTable.addCell(new Phrase(String.valueOf(entry.getValue()), normalFont));
+                }
+                document.add(timeTable);
+            }
+            document.add(Chunk.NEWLINE);
+
+            // Avg First Response Time
+            document.add(new Paragraph("Avg. First Response Time (hours)", sectionFont));
+            document.add(Chunk.NEWLINE);
+            addChartImage(document, chartImages, "responseTimeChart");
+            if (data.avgFirstResponseTime.isEmpty()) {
+                document.add(new Paragraph("No data available", normalFont));
+            } else {
+                PdfPTable responseTable = new PdfPTable(2);
+                responseTable.setWidthPercentage(100);
+                responseTable.addCell(createCell("Category", red, Color.WHITE));
+                responseTable.addCell(createCell("Avg. Hours", red, Color.WHITE));
+                for (Map.Entry<String, Double> entry : data.avgFirstResponseTime.entrySet()) {
+                    responseTable.addCell(new Phrase(entry.getKey(), normalFont));
+                    responseTable.addCell(new Phrase(String.valueOf(entry.getValue()), normalFont));
+                }
+                document.add(responseTable);
+            }
+            document.add(Chunk.NEWLINE);
+
+            // Resolution Histogram
+            document.add(new Paragraph("Resolution Time", sectionFont));
+            document.add(Chunk.NEWLINE);
+            addChartImage(document, chartImages, "histogramChart");
+            boolean hasHistogramData = data.resolutionHistogram.values().stream().anyMatch(list -> !list.isEmpty());
+            if (!hasHistogramData) {
+                document.add(new Paragraph("No data available", normalFont));
+                document.add(Chunk.NEWLINE);
+            } else {
+                PdfPTable histogramTable = new PdfPTable(3);
+                histogramTable.setWidthPercentage(100);
+                histogramTable.addCell(createCell("Duration", red, Color.WHITE));
+                histogramTable.addCell(createCell("Count", red, Color.WHITE));
+                histogramTable.addCell(createCell("Tickets", red, Color.WHITE));
+                for (Map.Entry<String, List<Ticket>> entry : data.resolutionHistogram.entrySet()) {
+                    List<Ticket> tickets = entry.getValue();
+                    histogramTable.addCell(new Phrase(entry.getKey(), normalFont));
+                    histogramTable.addCell(new Phrase(String.valueOf(tickets.size()), normalFont));
+                    if (tickets.isEmpty()) {
+                        histogramTable.addCell(new Phrase("-", normalFont));
+                    } else {
+                        StringBuilder names = new StringBuilder();
+                        for (int i = 0; i < tickets.size(); i++) {
+                            if (i > 0)
+                                names.append(", ");
+                            names.append(tickets.get(i).name);
+                        }
+                        histogramTable.addCell(new Phrase(names.toString(), normalFont));
+                    }
+                }
+                document.add(histogramTable);
+                document.add(Chunk.NEWLINE);
+            }
+
+            // Avg Resolution Time
+            document.add(new Paragraph("Avg. Resolution Time (hours)", sectionFont));
+            document.add(Chunk.NEWLINE);
+            addChartImage(document, chartImages, "resolutionTimeChart");
+            if (data.avgResolutionTime.isEmpty()) {
+                document.add(new Paragraph("No data available", normalFont));
+            } else {
+                PdfPTable resolutionTable = new PdfPTable(2);
+                resolutionTable.setWidthPercentage(100);
+                resolutionTable.addCell(createCell("Category", red, Color.WHITE));
+                resolutionTable.addCell(createCell("Avg. Hours", red, Color.WHITE));
+                for (Map.Entry<String, Double> entry : data.avgResolutionTime.entrySet()) {
+                    resolutionTable.addCell(new Phrase(entry.getKey(), normalFont));
+                    resolutionTable.addCell(new Phrase(String.valueOf(entry.getValue()), normalFont));
+                }
+                document.add(resolutionTable);
+            }
+            document.add(Chunk.NEWLINE);
+
             document.close();
             return outputStream.toByteArray();
         } catch (IOException e) {
@@ -255,4 +439,22 @@ public class PdfService {
         return Installation.find("SELECT i from Installation i WHERE i.singletonKey = 'installation'").firstResult();
     }
 
+    private void addChartImage(Document document, Map<String, String> chartImages, String key) {
+        if (chartImages == null)
+            return;
+        String base64 = chartImages.get(key);
+        if (base64 == null || base64.isBlank())
+            return;
+        try {
+            String data = base64.contains(",") ? base64.substring(base64.indexOf(',') + 1) : base64;
+            byte[] imageBytes = java.util.Base64.getDecoder().decode(data);
+            Image img = Image.getInstance(imageBytes);
+            img.scaleToFit(500, 200);
+            img.setAlignment(Image.ALIGN_LEFT);
+            document.add(img);
+            document.add(Chunk.NEWLINE);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to embed chart image: " + key, e);
+        }
+    }
 }

--- a/src/main/java/ai/mnemosyne_systems/web/ReportResource.java
+++ b/src/main/java/ai/mnemosyne_systems/web/ReportResource.java
@@ -17,12 +17,8 @@ import io.quarkus.qute.RawString;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.smallrye.common.annotation.Blocking;
-import jakarta.ws.rs.CookieParam;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -39,12 +35,20 @@ import java.util.TreeMap;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class ReportResource {
+    private static final String BUCKET_UNDER_1H = "< 1h";
+    private static final String BUCKET_1_TO_8H = "1–8h";
+    private static final String BUCKET_8_TO_24H = "8–24h";
+    private static final String BUCKET_1_TO_7D = "1–7 days";
+    private static final String BUCKET_OVER_7D = "> 7 days";
 
     @Location("report/reports.html")
     Template reportsTemplate;
 
     @Location("superuser/reports.html")
     Template superuserReportsTemplate;
+
+    @Inject
+    PdfService pdfService;
 
     @GET
     public TemplateInstance adminReports(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
@@ -73,6 +77,12 @@ public class ReportResource {
                 .data("responseTimeData", raw(toJsonDoubleArray(data.avgFirstResponseTime.values())))
                 .data("resolutionTimeLabels", raw(toJsonStringArray(data.avgResolutionTime.keySet())))
                 .data("resolutionTimeData", raw(toJsonDoubleArray(data.avgResolutionTime.values())))
+                .data("histogramLabels", raw(toJsonStringArray(data.resolutionHistogram.keySet())))
+                .data("histogramData",
+                        raw(toJsonNumberArray(data.resolutionHistogram.values().stream().map(List::size)
+                                .map(Long::valueOf).toList())))
+                .data("histogramTickets", data.resolutionHistogram).data("exportPath", "/reports/export")
+                .data("hasHistogramData", data.resolutionHistogram.values().stream().anyMatch(v -> !v.isEmpty()))
                 .data("totalTickets", data.totalTickets).data("period", safePeriod)
                 .data("showCompanyChart", selectedCompany == null);
     }
@@ -117,6 +127,12 @@ public class ReportResource {
                 .data("responseTimeData", raw(toJsonDoubleArray(data.avgFirstResponseTime.values())))
                 .data("resolutionTimeLabels", raw(toJsonStringArray(data.avgResolutionTime.keySet())))
                 .data("resolutionTimeData", raw(toJsonDoubleArray(data.avgResolutionTime.values())))
+                .data("histogramLabels", raw(toJsonStringArray(data.resolutionHistogram.keySet())))
+                .data("histogramData",
+                        raw(toJsonNumberArray(data.resolutionHistogram.values().stream().map(List::size)
+                                .map(Long::valueOf).toList())))
+                .data("histogramTickets", data.resolutionHistogram).data("exportPath", "/reports/tam/export")
+                .data("hasHistogramData", data.resolutionHistogram.values().stream().anyMatch(v -> !v.isEmpty()))
                 .data("totalTickets", data.totalTickets).data("period", safePeriod)
                 .data("showCompanyChart", showCompanyChart);
     }
@@ -161,7 +177,96 @@ public class ReportResource {
                 .data("responseTimeData", raw(toJsonDoubleArray(data.avgFirstResponseTime.values())))
                 .data("resolutionTimeLabels", raw(toJsonStringArray(data.avgResolutionTime.keySet())))
                 .data("resolutionTimeData", raw(toJsonDoubleArray(data.avgResolutionTime.values())))
+                .data("histogramLabels", raw(toJsonStringArray(data.resolutionHistogram.keySet())))
+                .data("histogramData",
+                        raw(toJsonNumberArray(data.resolutionHistogram.values().stream().map(List::size)
+                                .map(Long::valueOf).toList())))
+                .data("histogramTickets", data.resolutionHistogram).data("exportPath", "/reports/superuser/export")
+                .data("hasHistogramData", data.resolutionHistogram.values().stream().anyMatch(v -> !v.isEmpty()))
                 .data("totalTickets", data.totalTickets).data("period", safePeriod).data("showCompanyChart", false);
+    }
+
+    @POST
+    @Path("/export")
+    @Produces("application/pdf")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response exportAdminReport(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @QueryParam("companyId") Long companyId, @QueryParam("period") String period,
+            @FormParam("statusChart") String statusChart, @FormParam("categoryChart") String categoryChart,
+            @FormParam("companyChart") String companyChart, @FormParam("timeChart") String timeChart,
+            @FormParam("responseTimeChart") String responseTimeChart,
+            @FormParam("resolutionTimeChart") String resolutionTimeChart,
+            @FormParam("histogramChart") String histogramChart) {
+        requireAdmin(auth);
+        Company selectedCompany = companyId != null ? Company.findById(companyId) : null;
+        String safePeriod = period == null || period.isBlank() ? "all" : period.toLowerCase();
+        ReportData data = buildReportData(selectedCompany != null ? List.of(selectedCompany) : null, safePeriod);
+        String companyName = selectedCompany == null ? "All" : selectedCompany.name;
+        Map<String, String> chartImages = buildChartImages(statusChart, categoryChart, companyChart, timeChart,
+                responseTimeChart, resolutionTimeChart, histogramChart);
+        byte[] pdf = pdfService.generateReportPdf(data, companyName, safePeriod, selectedCompany == null, chartImages);
+        String filename = "report-" + companyName.toLowerCase().replace(" ", "-") + ".pdf";
+        return Response.ok(pdf).header("Content-Disposition", "attachment; filename=\"" + filename + "\"").build();
+    }
+
+    @POST
+    @Path("/tam/export")
+    @Produces("application/pdf")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response exportTamReport(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @QueryParam("companyId") Long companyId, @QueryParam("period") String period,
+            @FormParam("statusChart") String statusChart, @FormParam("categoryChart") String categoryChart,
+            @FormParam("companyChart") String companyChart, @FormParam("timeChart") String timeChart,
+            @FormParam("responseTimeChart") String responseTimeChart,
+            @FormParam("resolutionTimeChart") String resolutionTimeChart,
+            @FormParam("histogramChart") String histogramChart) {
+        User user = requireTam(auth);
+        List<Company> tamCompanies = Company.list(
+                "select distinct c from Company c join c.users u where u = ?1 and exists (select t from Ticket t where t.company = c) order by c.name",
+                user);
+        Company selectedCompany = null;
+        if (companyId != null) {
+            selectedCompany = tamCompanies.stream().filter(c -> c.id.equals(companyId)).findFirst().orElse(null);
+        }
+        String safePeriod = period == null || period.isBlank() ? "all" : period.toLowerCase();
+        List<Company> dataFilter = selectedCompany != null ? List.of(selectedCompany) : tamCompanies;
+        ReportData data = buildReportData(dataFilter, safePeriod);
+        String companyName = selectedCompany != null ? selectedCompany.name : "All";
+        Map<String, String> chartImages = buildChartImages(statusChart, categoryChart, null, timeChart,
+                responseTimeChart, resolutionTimeChart, histogramChart);
+        byte[] pdf = pdfService.generateReportPdf(data, companyName, safePeriod, false, chartImages);
+        String filename = "report-" + companyName.toLowerCase().replace(" ", "-") + ".pdf";
+        return Response.ok(pdf).header("Content-Disposition", "attachment; filename=\"" + filename + "\"").build();
+    }
+
+    @POST
+    @Path("/superuser/export")
+    @Produces("application/pdf")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response exportSuperuserReport(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @QueryParam("companyId") Long companyId, @QueryParam("period") String period,
+            @FormParam("statusChart") String statusChart, @FormParam("categoryChart") String categoryChart,
+            @FormParam("companyChart") String companyChart, @FormParam("timeChart") String timeChart,
+            @FormParam("responseTimeChart") String responseTimeChart,
+            @FormParam("resolutionTimeChart") String resolutionTimeChart,
+            @FormParam("histogramChart") String histogramChart) {
+        User user = requireSuperuser(auth);
+        List<Company> superuserCompanies = Company.list(
+                "select distinct c from Company c join c.users u where u = ?1 and exists (select t from Ticket t where t.company = c) order by c.name",
+                user);
+        Company selectedCompany = null;
+        if (companyId != null) {
+            selectedCompany = superuserCompanies.stream().filter(c -> c.id.equals(companyId)).findFirst().orElse(null);
+        }
+        String safePeriod = period == null || period.isBlank() ? "all" : period.toLowerCase();
+        List<Company> dataFilter = selectedCompany != null ? List.of(selectedCompany) : superuserCompanies;
+        ReportData data = buildReportData(dataFilter, safePeriod);
+        String companyName = selectedCompany != null ? selectedCompany.name : "All";
+        Map<String, String> chartImages = buildChartImages(statusChart, categoryChart, null, timeChart,
+                responseTimeChart, resolutionTimeChart, histogramChart);
+        byte[] pdf = pdfService.generateReportPdf(data, companyName, safePeriod, false, chartImages);
+        String filename = "report-" + companyName.toLowerCase().replace(" ", "-") + ".pdf";
+        return Response.ok(pdf).header("Content-Disposition", "attachment; filename=\"" + filename + "\"").build();
     }
 
     private ReportData buildReportData(List<Company> filterCompanies, String period) {
@@ -200,6 +305,7 @@ public class ReportResource {
         data.ticketsOverTime = buildTicketsOverTime(messagesByTicket, period);
         data.avgFirstResponseTime = buildAvgFirstResponseTime(tickets, messagesByTicket);
         data.avgResolutionTime = buildAvgResolutionTime(tickets, messagesByTicket);
+        data.resolutionHistogram = buildResolutionHistogram(tickets, messagesByTicket);
         return data;
     }
 
@@ -342,6 +448,44 @@ public class ReportResource {
         return result;
     }
 
+    private Map<String, List<Ticket>> buildResolutionHistogram(List<Ticket> tickets,
+            Map<Long, List<Message>> messagesByTicket) {
+        Map<String, List<Ticket>> histogram = new LinkedHashMap<>();
+        histogram.put(BUCKET_UNDER_1H, new ArrayList<>());
+        histogram.put(BUCKET_1_TO_8H, new ArrayList<>());
+        histogram.put(BUCKET_8_TO_24H, new ArrayList<>());
+        histogram.put(BUCKET_1_TO_7D, new ArrayList<>());
+        histogram.put(BUCKET_OVER_7D, new ArrayList<>());
+
+        for (Ticket ticket : tickets) {
+            if (!"Closed".equalsIgnoreCase(ticket.status)) {
+                continue;
+            }
+            List<Message> messages = messagesByTicket.get(ticket.id);
+            if (messages == null || messages.isEmpty()) {
+                continue;
+            }
+            Message first = messages.get(0);
+            Message last = messages.get(messages.size() - 1);
+            if (first.date == null || last.date == null) {
+                continue;
+            }
+            double hours = Duration.between(first.date, last.date).toMinutes() / 60.0;
+            if (hours < 1) {
+                histogram.get(BUCKET_UNDER_1H).add(ticket);
+            } else if (hours < 8) {
+                histogram.get(BUCKET_1_TO_8H).add(ticket);
+            } else if (hours < 24) {
+                histogram.get(BUCKET_8_TO_24H).add(ticket);
+            } else if (hours < 168) {
+                histogram.get(BUCKET_1_TO_7D).add(ticket);
+            } else {
+                histogram.get(BUCKET_OVER_7D).add(ticket);
+            }
+        }
+        return histogram;
+    }
+
     private RawString raw(String value) {
         return new RawString(value);
     }
@@ -388,6 +532,19 @@ public class ReportResource {
         return sb.append("]").toString();
     }
 
+    private Map<String, String> buildChartImages(String statusChart, String categoryChart, String companyChart,
+            String timeChart, String responseTimeChart, String resolutionTimeChart, String histogramChart) {
+        Map<String, String> images = new LinkedHashMap<>();
+        images.put("statusChart", statusChart);
+        images.put("categoryChart", categoryChart);
+        images.put("companyChart", companyChart);
+        images.put("timeChart", timeChart);
+        images.put("responseTimeChart", responseTimeChart);
+        images.put("resolutionTimeChart", resolutionTimeChart);
+        images.put("histogramChart", histogramChart);
+        return images;
+    }
+
     private User requireAdmin(String auth) {
         User user = AuthHelper.findUser(auth);
         if (!AuthHelper.isAdmin(user)) {
@@ -412,7 +569,7 @@ public class ReportResource {
         return user;
     }
 
-    private static class ReportData {
+    static class ReportData {
         int totalTickets;
         Map<String, Long> ticketsByStatus;
         Map<String, Long> ticketsByCategory;
@@ -420,5 +577,6 @@ public class ReportResource {
         Map<String, Long> ticketsOverTime;
         Map<String, Double> avgFirstResponseTime;
         Map<String, Double> avgResolutionTime;
+        Map<String, List<Ticket>> resolutionHistogram;
     }
 }

--- a/src/main/resources/templates/report/report-content.html
+++ b/src/main/resources/templates/report/report-content.html
@@ -26,7 +26,7 @@
     <p style="margin-bottom:16px;"><strong>Company:</strong> {companyName}</p>
 {/if}
 
-<p style="margin-bottom:16px;">Total tickets: <strong>{totalTickets}</strong></p>
+<p style="margin:0;">Total tickets: <strong>{totalTickets}</strong></p>
 
 <style>
     .report-grid {
@@ -114,6 +114,40 @@
             </div>
         </div>
         <div class="report-card">
+            <h2 class="report-title">Resolution Time</h2>
+            <div id="histogramContainer" class="report-chart-container">
+                <canvas id="histogramChart"></canvas>
+            </div>
+            {#if hasHistogramData}
+                <table style="width:100%; margin-top:12px; border-collapse:collapse; font-size:13px;">
+                    <thead>
+                    <tr>
+                        <th style="text-align:left; padding:4px 8px; border-bottom:1px solid var(--card-border);">Duration</th>
+                        <th style="text-align:left; padding:4px 8px; border-bottom:1px solid var(--card-border);">Count</th>
+                        <th style="text-align:left; padding:4px 8px; border-bottom:1px solid var(--card-border);">Tickets</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {#for entry in histogramTickets.entrySet()}
+                        <tr>
+                            <td style="padding:4px 8px;">{entry.key}</td>
+                            <td style="padding:4px 8px;">{entry.value.size()}</td>
+                            <td style="padding:4px 8px;">
+                                {#if entry.value.isEmpty()}
+                                    —
+                                {#else}
+                                    {#for ticket in entry.value}
+                                        <a href="/tickets/{ticket.id}">{ticket.name}</a>{#if ticket_hasNext}, {/if}
+                                    {/for}
+                                {/if}
+                            </td>
+                        </tr>
+                    {/for}
+                    </tbody>
+                </table>
+            {/if}
+        </div>
+        <div class="report-card">
             <h2 class="report-title">Avg. Resolution Time (hours)</h2>
             <div id="resolutionTimeContainer" class="report-chart-container">
                 <canvas id="resolutionTimeChart"></canvas>
@@ -121,7 +155,12 @@
         </div>
     </div>
 
-    <script src="/webjars/chart.js/4.4.7/dist/chart.umd.js"></script>
+    <button onclick="exportReport()"
+            style="display:inline-block; margin-top:24px; padding:10px 20px; background:#b00020; color:#fff; border-radius:4px; border:none; cursor:pointer; font-size:14px; font-weight:600; box-shadow:0 2px 8px rgba(0,0,0,0.25);">
+        Export
+    </button>
+
+    <script src="/webjars/chart.js/4.5.1/dist/chart.umd.js"></script>
     <script>
         var statusLabels = {statusLabels};
         var statusData = {statusData};
@@ -135,6 +174,8 @@
         var responseTimeData = {responseTimeData};
         var resolutionTimeLabels = {resolutionTimeLabels};
         var resolutionTimeData = {resolutionTimeData};
+        var histogramLabels = {histogramLabels};
+        var histogramData = {histogramData};
 
         var statusColors = {
             'Open': '#4285f4',
@@ -171,7 +212,7 @@
             maintainAspectRatio: false
         };
 
-        new Chart(document.getElementById('statusChart'), {
+        var statusChartInstance = new Chart(document.getElementById('statusChart'), {
             type: 'pie',
             data: {
                 labels: statusLabels,
@@ -190,7 +231,7 @@
             }
         });
 
-        new Chart(document.getElementById('categoryChart'), {
+        var categoryChartInstance = new Chart(document.getElementById('categoryChart'), {
             type: 'bar',
             data: {
                 labels: categoryLabels,
@@ -212,7 +253,7 @@
 
         var companyCanvas = document.getElementById('companyChart');
         if (companyCanvas) {
-            new Chart(companyCanvas, {
+            var companyChartInstance = new Chart(companyCanvas, {
                 type: 'bar',
                 data: {
                     labels: companyLabels,
@@ -234,7 +275,7 @@
         }
 
         if (timeLabels.length > 0) {
-            new Chart(document.getElementById('timeChart'), {
+            var timeChartInstance = new Chart(document.getElementById('timeChart'), {
                 type: 'line',
                 data: {
                     labels: timeLabels,
@@ -261,7 +302,7 @@
         }
 
         if (responseTimeLabels.length > 0) {
-            new Chart(document.getElementById('responseTimeChart'), {
+            var responseTimeChartInstance = new Chart(document.getElementById('responseTimeChart'), {
                 type: 'bar',
                 data: {
                     labels: responseTimeLabels,
@@ -285,7 +326,7 @@
         }
 
         if (resolutionTimeLabels.length > 0) {
-            new Chart(document.getElementById('resolutionTimeChart'), {
+            var resolutionTimeChartInstance = new Chart(document.getElementById('resolutionTimeChart'), {
                 type: 'bar',
                 data: {
                     labels: resolutionTimeLabels,
@@ -306,6 +347,59 @@
             });
         } else {
             showNoData('resolutionTimeContainer');
+        }
+
+        if (histogramData.some(function(v) { return v > 0; })) {
+            var histogramChartInstance = new Chart(document.getElementById('histogramChart'), {
+                type: 'bar',
+                data: {
+                    labels: histogramLabels,
+                    datasets: [{
+                        label: 'Tickets',
+                        data: histogramData,
+                        backgroundColor: [
+                            defaultColors[0], defaultColors[1], defaultColors[2], defaultColors[3], defaultColors[4]
+                        ],
+                        borderWidth: 0
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        y: { beginAtZero: true, ticks: { stepSize: 1 } }
+                    }
+                }
+            });
+        } else {
+            showNoData('histogramContainer');
+        }
+
+        function exportReport() {
+            var form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '{exportPath}?{#if selectedCompanyId != null}companyId={selectedCompanyId}&{/if}period={period}';
+
+            function addImage(name, instance) {
+                var input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = name;
+                input.value = instance ? instance.toBase64Image() : '';
+                form.appendChild(input);
+            }
+
+            addImage('statusChart', statusChartInstance);
+            addImage('categoryChart', categoryChartInstance);
+            addImage('companyChart', typeof companyChartInstance !== 'undefined' ? companyChartInstance : null);
+            addImage('timeChart', typeof timeChartInstance !== 'undefined' ? timeChartInstance : null);
+            addImage('responseTimeChart', typeof responseTimeChartInstance !== 'undefined' ? responseTimeChartInstance : null);
+            addImage('resolutionTimeChart', typeof resolutionTimeChartInstance !== 'undefined' ? resolutionTimeChartInstance : null);
+            addImage('histogramChart', typeof histogramChartInstance !== 'undefined' ? histogramChartInstance : null);
+
+            document.body.appendChild(form);
+            form.submit();
+            document.body.removeChild(form);
         }
 
         document.getElementById('periodSelect').addEventListener('change', function() {
@@ -336,6 +430,10 @@
         </div>
         <div class="report-card">
             <h2 class="report-title">Avg. First Response Time (hours)</h2>
+            <div class="report-no-data">No data available</div>
+        </div>
+        <div class="report-card">
+            <h2 class="report-title">Resolution Time</h2>
             <div class="report-no-data">No data available</div>
         </div>
         <div class="report-card">


### PR DESCRIPTION
Closes #62

- Added `generateReportPdf` to `PdfService` with sections for all current report metrics.
- Added resolution time histogram that buckets closed tickets by duration.



### Screenshot
<img width="640" height="469" alt="image" src="https://github.com/user-attachments/assets/b6800613-f6d9-4aae-9a12-fded9ff4e7e8" />

### PDF
[report-all.pdf](https://github.com/user-attachments/files/25795964/report-all.pdf)
