### PR TITLE
Redirect fix in support user while assigning

### DIFF
--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
@@ -354,9 +354,10 @@ public class SupportResource {
     @Path("/tickets/{id}")
     @Transactional
     public Response updateTicket(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
-            @jakarta.ws.rs.PathParam("id") Long id, @FormParam("status") String status,
-            @FormParam("companyId") Long companyId, @FormParam("companyEntitlementId") Long companyEntitlementId,
-            @FormParam("categoryId") Long categoryId, @FormParam("externalIssueLink") String externalIssueLink,
+            @HeaderParam("X-Billetsys-Client") String client, @jakarta.ws.rs.PathParam("id") Long id,
+            @FormParam("status") String status, @FormParam("companyId") Long companyId,
+            @FormParam("companyEntitlementId") Long companyEntitlementId, @FormParam("categoryId") Long categoryId,
+            @FormParam("externalIssueLink") String externalIssueLink,
             @FormParam("affectsVersionId") Long affectsVersionId,
             @FormParam("resolvedVersionId") Long resolvedVersionId) {
         User user = requireSupport(auth);
@@ -402,14 +403,14 @@ public class SupportResource {
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
-        return Response.seeOther(URI.create("/support/tickets/" + id)).build();
+        return createTicketRedirect(client, "/support/tickets/" + id);
     }
 
     @POST
     @Path("/tickets/{id}/assign")
     @Transactional
     public Response assignTicket(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
-            @jakarta.ws.rs.PathParam("id") Long id) {
+            @HeaderParam("X-Billetsys-Client") String client, @jakarta.ws.rs.PathParam("id") Long id) {
         User user = requireSupport(auth);
         Ticket ticket = Ticket.findById(id);
         if (ticket == null) {
@@ -426,7 +427,7 @@ public class SupportResource {
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
-        return Response.seeOther(URI.create("/support/tickets/" + id)).build();
+        return createTicketRedirect(client, "/support/tickets/" + id);
     }
 
     private void assignCompanyTams(Ticket ticket) {

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -104,7 +104,9 @@ export default function SupportTicketDetailPage({
         ['externalIssueLink', formState.externalIssueLink],
         ['affectsVersionId', formState.affectsVersionId],
         ['resolvedVersionId', formState.resolvedVersionId || null]
-      ]);
+      ], {
+        headers: { 'X-Billetsys-Client': 'react' }
+      });
       setRefreshNonce(current => current + 1);
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });

--- a/src/frontend/src/utils/api.ts
+++ b/src/frontend/src/utils/api.ts
@@ -10,6 +10,10 @@ export type FormValue = string | number | boolean | File | null | undefined;
 export type FormEntryValue = FormValue | FormValue[];
 export type FormEntries = Array<[string, FormEntryValue]>;
 
+interface FormOptions {
+  headers?: HeadersInit;
+}
+
 interface MultipartOptions {
   headers?: HeadersInit;
 }
@@ -23,19 +27,22 @@ export async function fetchJson<T>(url: string): Promise<T> {
     throw new Error('You do not have access to this page.');
   }
   if (!response.ok) {
-    throw new Error((await response.text()) || `Unable to load ${url}`);
+    throw new Error(toErrorMessage(await response.text(), `Unable to load ${url}`));
   }
   return response.json() as Promise<T>;
 }
 
-export async function postForm(url: string, entries: FormEntries): Promise<Response> {
+export async function postForm(url: string, entries: FormEntries, options: FormOptions = {}): Promise<Response> {
   const body = new URLSearchParams();
   entries.forEach(([key, value]) => appendSearchValue(body, key, value));
 
   const response = await fetch(url, {
     method: 'POST',
     credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      ...options.headers
+    },
     body: body.toString()
   });
 
@@ -46,7 +53,7 @@ export async function postForm(url: string, entries: FormEntries): Promise<Respo
     throw new Error('You do not have access to this action.');
   }
   if (!response.ok) {
-    throw new Error((await response.text()) || 'Unable to save.');
+    throw new Error(toErrorMessage(await response.text(), 'Unable to save.'));
   }
 
   return response;
@@ -70,7 +77,7 @@ export async function postMultipart(url: string, entries: FormEntries, options: 
     throw new Error('You do not have access to this action.');
   }
   if (!response.ok) {
-    throw new Error((await response.text()) || 'Unable to save.');
+    throw new Error(toErrorMessage(await response.text(), 'Unable to save.'));
   }
 
   return response;
@@ -96,5 +103,16 @@ function appendSearchValue(searchParams: URLSearchParams, key: string, value: Fo
     return;
   }
   searchParams.append(key, String(value));
+}
+
+function toErrorMessage(text: string, fallback: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  if (trimmed.startsWith('<!doctype html') || trimmed.startsWith('<html')) {
+    return fallback;
+  }
+  return trimmed;
 }
 


### PR DESCRIPTION
This PR fixes the support ticket save flow for React clients when a support user updates a ticket. The ticket update was being saved correctly, but the frontend request could end up following a redirect loop and show `ERR_TOO_MANY_REDIRECTS `in the browser console.

What Changed

- Updated the React support ticket save flow to send a React-client header.
- Updated the backend support ticket update/assign flow to return a React-friendly redirect response for React clients.
- Extended the shared postForm helper so the save flow can send custom headers cleanly.