### PR TITLE
[#87] API Requests fix

### DIFF
--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ArticleResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ArticleResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -83,7 +84,8 @@ public class ArticleResource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Transactional
-    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, MultipartFormDataInput input) {
+    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, MultipartFormDataInput input) {
         requireCreateEdit(auth);
         String title = AttachmentHelper.readFormValue(input, "title");
         String tags = AttachmentHelper.readFormValue(input, "tags");
@@ -97,7 +99,7 @@ public class ArticleResource {
         List<Attachment> attachments = storeAttachments(article,
                 AttachmentHelper.readAttachments(input, "attachments"));
         article.body = resolveInlineAttachmentUrls(article.body, attachments);
-        return Response.seeOther(URI.create("/articles")).build();
+        return ReactRedirectSupport.redirect(client, "/articles");
     }
 
     @POST
@@ -105,7 +107,7 @@ public class ArticleResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Transactional
     public Response update(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            MultipartFormDataInput input) {
+            @HeaderParam("X-Billetsys-Client") String client, MultipartFormDataInput input) {
         requireCreateEdit(auth);
         Article article = Article
                 .find("select distinct a from Article a left join fetch a.attachments where a.id = ?1", id)
@@ -123,20 +125,21 @@ public class ArticleResource {
         List<Attachment> attachments = storeAttachments(article,
                 AttachmentHelper.readAttachments(input, "attachments"));
         article.body = resolveInlineAttachmentUrls(article.body, attachments);
-        return Response.seeOther(URI.create("/articles/" + id)).build();
+        return ReactRedirectSupport.redirect(client, "/articles/" + id);
     }
 
     @POST
     @Path("/{id}/delete")
     @Transactional
-    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireAdmin(auth);
         Article article = Article.findById(id);
         if (article == null) {
             throw new NotFoundException();
         }
         article.delete();
-        return Response.seeOther(URI.create("/articles")).build();
+        return ReactRedirectSupport.redirect(client, "/articles");
     }
 
     private List<Attachment> storeAttachments(Article article, List<Attachment> uploaded) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/CategoryResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/CategoryResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -76,7 +77,8 @@ public class CategoryResource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Transactional
-    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, MultipartFormDataInput input) {
+    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, MultipartFormDataInput input) {
         requireAdmin(auth);
         String name = AttachmentHelper.readFormValue(input, "name");
         String description = AttachmentHelper.readFormValue(input, "description");
@@ -96,7 +98,7 @@ public class CategoryResource {
         List<Attachment> attachments = storeAttachments(category,
                 AttachmentHelper.readAttachments(input, "attachments"));
         category.description = resolveInlineAttachmentUrls(category.description, attachments);
-        return Response.seeOther(URI.create("/categories")).build();
+        return ReactRedirectSupport.redirect(client, "/categories");
     }
 
     @POST
@@ -104,7 +106,7 @@ public class CategoryResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Transactional
     public Response update(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            MultipartFormDataInput input) {
+            @HeaderParam("X-Billetsys-Client") String client, MultipartFormDataInput input) {
         requireAdmin(auth);
         Category category = Category
                 .find("select distinct c from Category c left join fetch c.attachments where c.id = ?1", id)
@@ -128,7 +130,7 @@ public class CategoryResource {
         List<Attachment> attachments = storeAttachments(category,
                 AttachmentHelper.readAttachments(input, "attachments"));
         category.description = resolveInlineAttachmentUrls(category.description, attachments);
-        return Response.seeOther(URI.create("/categories")).build();
+        return ReactRedirectSupport.redirect(client, "/categories");
     }
 
     static Category findCategoryWithAttachments(Long id) {
@@ -152,7 +154,8 @@ public class CategoryResource {
     @POST
     @Path("/{id}/delete")
     @Transactional
-    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireAdmin(auth);
         Category category = Category.findById(id);
         if (category == null) {
@@ -160,7 +163,7 @@ public class CategoryResource {
         }
         Attachment.delete("category", category);
         category.delete();
-        return Response.seeOther(URI.create("/categories")).build();
+        return ReactRedirectSupport.redirect(client, "/categories");
     }
 
     private List<Attachment> storeAttachments(Category category, List<Attachment> uploaded) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/CompanyResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/CompanyResource.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -80,7 +81,8 @@ public class CompanyResource {
     @POST
     @Path("")
     @Transactional
-    public Response createCompany(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @FormParam("name") String name,
+    public Response createCompany(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
             @FormParam("address1") String address1, @FormParam("address2") String address2,
             @FormParam("city") String city, @FormParam("state") String state, @FormParam("zip") String zip,
             @FormParam("countryId") Long countryId, @FormParam("timezoneId") Long timezoneId,
@@ -123,18 +125,18 @@ public class CompanyResource {
         company.persist();
         applyEntitlements(company, entitlementIds, levelIds, entitlementDates, entitlementDurations,
                 java.util.List.of());
-        return Response.seeOther(URI.create("/companies")).build();
+        return ReactRedirectSupport.redirect(client, "/companies");
     }
 
     @POST
     @Path("{id}")
     @Transactional
     public Response updateCompany(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            @FormParam("name") String name, @FormParam("address1") String address1,
-            @FormParam("address2") String address2, @FormParam("city") String city, @FormParam("state") String state,
-            @FormParam("zip") String zip, @FormParam("countryId") Long countryId,
-            @FormParam("timezoneId") Long timezoneId, @FormParam("userIds") java.util.List<Long> userIds,
-            @FormParam("tamIds") java.util.List<Long> tamIds,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
+            @FormParam("address1") String address1, @FormParam("address2") String address2,
+            @FormParam("city") String city, @FormParam("state") String state, @FormParam("zip") String zip,
+            @FormParam("countryId") Long countryId, @FormParam("timezoneId") Long timezoneId,
+            @FormParam("userIds") java.util.List<Long> userIds, @FormParam("tamIds") java.util.List<Long> tamIds,
             @FormParam("entitlementIds") java.util.List<Long> entitlementIds,
             @FormParam("levelIds") java.util.List<Long> levelIds,
             @FormParam("entitlementDates") java.util.List<String> entitlementDates,
@@ -195,20 +197,21 @@ public class CompanyResource {
             }
             entry.delete();
         }
-        return Response.seeOther(URI.create("/companies")).build();
+        return ReactRedirectSupport.redirect(client, "/companies");
     }
 
     @POST
     @Path("{id}/delete")
     @Transactional
-    public Response deleteCompany(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response deleteCompany(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireAdmin(auth);
         Company company = Company.findById(id);
         if (company == null) {
             throw new NotFoundException();
         }
         company.delete();
-        return Response.seeOther(URI.create("/companies")).build();
+        return ReactRedirectSupport.redirect(client, "/companies");
     }
 
     private User requireAdmin(String auth) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/EntitlementResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/EntitlementResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -77,7 +78,8 @@ public class EntitlementResource {
     @POST
     @Path("")
     @Transactional
-    public Response createEntitlement(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @FormParam("name") String name,
+    public Response createEntitlement(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
             @FormParam("description") String description, @FormParam("levelIds") List<Long> levelIds,
             @FormParam("versionIds") List<String> versionIds, @FormParam("versionNames") List<String> versionNames,
             @FormParam("versionDates") List<String> versionDates) {
@@ -90,16 +92,16 @@ public class EntitlementResource {
         entitlement.versions.clear();
         entitlement.versions.addAll(resolveVersions(entitlement, null, versionIds, versionNames, versionDates));
         entitlement.persist();
-        return Response.seeOther(URI.create("/entitlements")).build();
+        return ReactRedirectSupport.redirect(client, "/entitlements");
     }
 
     @POST
     @Path("{id}")
     @Transactional
     public Response updateEntitlement(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            @FormParam("name") String name, @FormParam("description") String description,
-            @FormParam("levelIds") List<Long> levelIds, @FormParam("versionIds") List<String> versionIds,
-            @FormParam("versionNames") List<String> versionNames,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
+            @FormParam("description") String description, @FormParam("levelIds") List<Long> levelIds,
+            @FormParam("versionIds") List<String> versionIds, @FormParam("versionNames") List<String> versionNames,
             @FormParam("versionDates") List<String> versionDates) {
         requireAdmin(auth);
         Entitlement entitlement = Entitlement
@@ -116,20 +118,21 @@ public class EntitlementResource {
                 versionDates);
         entitlement.versions.clear();
         entitlement.versions.addAll(resolvedVersions);
-        return Response.seeOther(URI.create("/entitlements")).build();
+        return ReactRedirectSupport.redirect(client, "/entitlements");
     }
 
     @POST
     @Path("{id}/delete")
     @Transactional
-    public Response deleteEntitlement(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response deleteEntitlement(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireAdmin(auth);
         Entitlement entitlement = Entitlement.findById(id);
         if (entitlement == null) {
             throw new NotFoundException();
         }
         entitlement.delete();
-        return Response.seeOther(URI.create("/entitlements")).build();
+        return ReactRedirectSupport.redirect(client, "/entitlements");
     }
 
     private void validate(String name, String description) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/LevelResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/LevelResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -94,7 +95,8 @@ public class LevelResource {
     @POST
     @Path("")
     @Transactional
-    public Response createLevel(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @FormParam("name") String name,
+    public Response createLevel(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
             @FormParam("description") String description, @FormParam("level") Integer levelValue,
             @FormParam("color") String color, @FormParam("fromDay") Integer fromDay,
             @FormParam("fromTime") Integer fromTime, @FormParam("toDay") Integer toDay,
@@ -121,18 +123,19 @@ public class LevelResource {
         level.timezone = timezoneId != null ? Timezone.findById(timezoneId)
                 : Timezone.find("name", "America/New_York").firstResult();
         level.persist();
-        return Response.seeOther(URI.create("/levels")).build();
+        return ReactRedirectSupport.redirect(client, "/levels");
     }
 
     @POST
     @Path("{id}")
     @Transactional
     public Response updateLevel(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            @FormParam("name") String name, @FormParam("description") String description,
-            @FormParam("level") Integer levelValue, @FormParam("color") String color,
-            @FormParam("fromDay") Integer fromDay, @FormParam("fromTime") Integer fromTime,
-            @FormParam("toDay") Integer toDay, @FormParam("toTime") Integer toTime,
-            @FormParam("countryId") Long countryId, @FormParam("timezoneId") Long timezoneId) {
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
+            @FormParam("description") String description, @FormParam("level") Integer levelValue,
+            @FormParam("color") String color, @FormParam("fromDay") Integer fromDay,
+            @FormParam("fromTime") Integer fromTime, @FormParam("toDay") Integer toDay,
+            @FormParam("toTime") Integer toTime, @FormParam("countryId") Long countryId,
+            @FormParam("timezoneId") Long timezoneId) {
         requireAdmin(auth);
         Level level = Level.findById(id);
         if (level == null) {
@@ -160,20 +163,21 @@ public class LevelResource {
         level.country = countryId != null ? Country.findById(countryId) : Country.find("code", "US").firstResult();
         level.timezone = timezoneId != null ? Timezone.findById(timezoneId)
                 : Timezone.find("name", "America/New_York").firstResult();
-        return Response.seeOther(URI.create("/levels")).build();
+        return ReactRedirectSupport.redirect(client, "/levels");
     }
 
     @POST
     @Path("{id}/delete")
     @Transactional
-    public Response deleteLevel(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response deleteLevel(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireAdmin(auth);
         Level level = Level.findById(id);
         if (level == null) {
             throw new NotFoundException();
         }
         level.delete();
-        return Response.seeOther(URI.create("/levels")).build();
+        return ReactRedirectSupport.redirect(client, "/levels");
     }
 
     private void validate(String name, String description, Integer levelValue, String color, Integer fromDay,

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/MessageResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/MessageResource.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -77,7 +78,8 @@ public class MessageResource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Transactional
-    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, MultipartFormDataInput input) {
+    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, MultipartFormDataInput input) {
         User user = requireSupport(auth);
         String body = AttachmentHelper.readFormValue(input, "body");
         String date = AttachmentHelper.readFormValue(input, "date");
@@ -88,7 +90,7 @@ public class MessageResource {
         message.persistAndFlush();
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(message.ticket, message, user);
-        return Response.seeOther(URI.create("/messages")).build();
+        return ReactRedirectSupport.redirect(client, "/messages");
     }
 
     @POST
@@ -96,7 +98,7 @@ public class MessageResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Transactional
     public Response update(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            MultipartFormDataInput input) {
+            @HeaderParam("X-Billetsys-Client") String client, MultipartFormDataInput input) {
         User user = requireSupport(auth);
         String body = AttachmentHelper.readFormValue(input, "body");
         String date = AttachmentHelper.readFormValue(input, "date");
@@ -110,20 +112,21 @@ public class MessageResource {
         AttachmentHelper.attachToMessage(message, attachments);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(message.ticket, message, user);
-        return Response.seeOther(URI.create("/messages")).build();
+        return ReactRedirectSupport.redirect(client, "/messages");
     }
 
     @POST
     @Path("/{id}/delete")
     @Transactional
-    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireSupport(auth);
         Message message = Message.findById(id);
         if (message == null) {
             throw new NotFoundException();
         }
         message.delete();
-        return Response.seeOther(URI.create("/messages")).build();
+        return ReactRedirectSupport.redirect(client, "/messages");
     }
 
     private Message buildMessage(Message existing, User author, String body, String date, Long ticketId) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ReactRedirectSupport.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ReactRedirectSupport.java
@@ -1,0 +1,29 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.resource;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+
+final class ReactRedirectSupport {
+
+    private ReactRedirectSupport() {
+    }
+
+    static Response redirect(String client, String path) {
+        if ("react".equalsIgnoreCase(client)) {
+            return Response.ok(new RedirectResponse(path)).type(MediaType.APPLICATION_JSON).build();
+        }
+        return Response.seeOther(URI.create(path)).build();
+    }
+
+    record RedirectResponse(String redirectTo) {
+    }
+}

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
@@ -319,7 +319,8 @@ public class SuperuserResource {
     @POST
     @Path("superuser/tickets/{id}")
     @Transactional
-    public Response updateTicket(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
+    public Response updateTicket(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id,
             @FormParam("affectsVersionId") Long affectsVersionId,
             @FormParam("resolvedVersionId") Long resolvedVersionId) {
         User user = requireSuperuser(auth);
@@ -329,7 +330,7 @@ public class SuperuserResource {
         }
         ticket.affectsVersion = resolveVersionForTicket(ticket, affectsVersionId, "Affects");
         ticket.resolvedVersion = resolveOptionalVersionForTicket(ticket, resolvedVersionId, "Resolved");
-        return Response.seeOther(URI.create("/superuser/tickets/" + id)).build();
+        return ReactRedirectSupport.redirect(client, "/superuser/tickets/" + id);
     }
 
     static List<Ticket> loadScopedTickets(User user) {
@@ -736,11 +737,7 @@ public class SuperuserResource {
     }
 
     private Response createTicketRedirect(String client, String path) {
-        if ("react".equalsIgnoreCase(client)) {
-            return Response.ok(new SupportTicketApiResource.RedirectResponse(path)).type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-        return Response.seeOther(URI.create(path)).build();
+        return ReactRedirectSupport.redirect(client, path);
     }
 
     private Version resolveVersionForTicket(Ticket ticket, Long versionId, String label) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
@@ -501,11 +501,7 @@ public class SupportResource {
     }
 
     private Response createTicketRedirect(String client, String path) {
-        if ("react".equalsIgnoreCase(client)) {
-            return Response.ok(new SupportTicketApiResource.RedirectResponse(path)).type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-        return Response.seeOther(URI.create(path)).build();
+        return ReactRedirectSupport.redirect(client, path);
     }
 
     private String formatDate(LocalDateTime date) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/TicketResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/TicketResource.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -153,7 +154,8 @@ public class TicketResource {
 
     @POST
     @Transactional
-    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @FormParam("status") String status,
+    public Response create(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("status") String status,
             @FormParam("companyId") Long companyId, @FormParam("companyEntitlementId") Long companyEntitlementId,
             @FormParam("categoryId") Long categoryId) {
         User user = requireSupport(auth);
@@ -185,16 +187,16 @@ public class TicketResource {
         ticket.affectsVersion = defaultAffectsVersion(entitlement);
         ticket.category = category;
         ticket.persist();
-        return Response.seeOther(URI.create("/tickets")).build();
+        return ReactRedirectSupport.redirect(client, "/tickets");
     }
 
     @POST
     @Path("/{id}")
     @Transactional
     public Response update(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            @FormParam("status") String status, @FormParam("companyId") Long companyId,
-            @FormParam("companyEntitlementId") Long companyEntitlementId, @FormParam("categoryId") Long categoryId,
-            @FormParam("externalIssueLink") String externalIssueLink,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("status") String status,
+            @FormParam("companyId") Long companyId, @FormParam("companyEntitlementId") Long companyEntitlementId,
+            @FormParam("categoryId") Long categoryId, @FormParam("externalIssueLink") String externalIssueLink,
             @FormParam("affectsVersionId") Long affectsVersionId,
             @FormParam("resolvedVersionId") Long resolvedVersionId) {
         User user = requireSupport(auth);
@@ -233,20 +235,21 @@ public class TicketResource {
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
-        return Response.seeOther(URI.create("/tickets")).build();
+        return ReactRedirectSupport.redirect(client, "/tickets");
     }
 
     @POST
     @Path("/{id}/delete")
     @Transactional
-    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireSupport(auth);
         Ticket ticket = Ticket.findById(id);
         if (ticket == null) {
             throw new NotFoundException();
         }
         ticket.delete();
-        return Response.seeOther(URI.create("/tickets")).build();
+        return ReactRedirectSupport.redirect(client, "/tickets");
     }
 
     @GET

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -381,7 +381,7 @@ public class UserResource {
     @Path("user/tickets/{id}")
     @Transactional
     public Response updateUserTicket(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            @FormParam("affectsVersionId") Long affectsVersionId,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("affectsVersionId") Long affectsVersionId,
             @FormParam("resolvedVersionId") Long resolvedVersionId) {
         User user = requireUser(auth);
         Ticket ticket = findTicketForUser(user, id);
@@ -392,7 +392,7 @@ public class UserResource {
         if (User.TYPE_TAM.equalsIgnoreCase(user.type)) {
             ticket.resolvedVersion = resolveOptionalVersionForTicket(ticket, resolvedVersionId, "Resolved");
         }
-        return Response.seeOther(URI.create("/tickets/" + id)).build();
+        return ReactRedirectSupport.redirect(client, "/tickets/" + id);
     }
 
     @GET
@@ -450,7 +450,8 @@ public class UserResource {
     @POST
     @Path("users")
     @Transactional
-    public Response createAdminUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @FormParam("name") String name,
+    public Response createAdminUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
             @FormParam("fullName") String fullName, @FormParam("email") String email,
             @FormParam("social") String social, @FormParam("phoneNumber") String phoneNumber,
             @FormParam("phoneExtension") String phoneExtension, @FormParam("timezoneId") Long timezoneId,
@@ -478,14 +479,15 @@ public class UserResource {
                 company.users.add(newUser);
             }
         }
-        return Response.seeOther(URI.create("/users")).build();
+        return ReactRedirectSupport.redirect(client, "/users");
     }
 
     @POST
     @Path("user/{id}")
     @Transactional
     public Response updateAdminUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
-            @FormParam("name") String name, @FormParam("fullName") String fullName, @FormParam("email") String email,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("name") String name,
+            @FormParam("fullName") String fullName, @FormParam("email") String email,
             @FormParam("social") String social, @FormParam("phoneNumber") String phoneNumber,
             @FormParam("phoneExtension") String phoneExtension, @FormParam("timezoneId") Long timezoneId,
             @FormParam("countryId") Long countryId, @FormParam("type") String type,
@@ -521,7 +523,7 @@ public class UserResource {
                 company.users.add(editUser);
             }
         }
-        return Response.seeOther(URI.create("/users")).build();
+        return ReactRedirectSupport.redirect(client, "/users");
     }
 
     private String trimOrNull(String value) {
@@ -534,14 +536,45 @@ public class UserResource {
     @POST
     @Path("user/{id}/delete")
     @Transactional
-    public Response deleteAdminUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id) {
+    public Response deleteAdminUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
         requireAdmin(auth);
         User deleteUser = User.findById(id);
         if (deleteUser == null) {
             throw new NotFoundException();
         }
+        if (Company.count("superuser = ?1", deleteUser) > 0) {
+            throw new BadRequestException("Reassign this company superuser before deleting the user.");
+        }
+        removeUserReferences(deleteUser);
         deleteUser.delete();
-        return Response.seeOther(URI.create("/users")).build();
+        return ReactRedirectSupport.redirect(client, "/users");
+    }
+
+    private void removeUserReferences(User user) {
+        List<Company> companies = Company
+                .find("select distinct c from Company c left join c.users u where u = ?1", user).list();
+        for (Company company : companies) {
+            company.users.removeIf(existing -> existing.id != null && existing.id.equals(user.id));
+        }
+        List<Ticket> supportTickets = Ticket
+                .find("select distinct t from Ticket t join t.supportUsers u where u = ?1", user).list();
+        for (Ticket ticket : supportTickets) {
+            ticket.supportUsers.removeIf(existing -> existing.id != null && existing.id.equals(user.id));
+        }
+        List<Ticket> tamTickets = Ticket.find("select distinct t from Ticket t join t.tamUsers u where u = ?1", user)
+                .list();
+        for (Ticket ticket : tamTickets) {
+            ticket.tamUsers.removeIf(existing -> existing.id != null && existing.id.equals(user.id));
+        }
+        List<Ticket> requesterTickets = Ticket.find("requester = ?1", user).list();
+        for (Ticket ticket : requesterTickets) {
+            ticket.requester = null;
+        }
+        List<Message> messages = Message.find("author = ?1", user).list();
+        for (Message message : messages) {
+            message.author = null;
+        }
     }
 
     private void validateUserFields(String name, String email, String type, boolean requirePassword, String password) {
@@ -931,11 +964,7 @@ public class UserResource {
     }
 
     private Response createTicketRedirect(String client, String path) {
-        if ("react".equalsIgnoreCase(client)) {
-            return Response.ok(new SupportTicketApiResource.RedirectResponse(path)).type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-        return Response.seeOther(URI.create(path)).build();
+        return ReactRedirectSupport.redirect(client, path);
     }
 
     private Version resolveVersionForTicket(Ticket ticket, Long versionId, String label) {

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/AdminAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/AdminAccessTest.java
@@ -383,4 +383,106 @@ class AdminAccessTest extends AccessTestSupport {
         Assertions.assertTrue(companyHasUser(ownerCompany.id, "tam1@mnemosyne-systems.ai"));
     }
 
+    @Test
+    void reactAdminMutationsReturnJsonRedirects() {
+        ensureUser("admin-json", "admin-json@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin-json");
+        String cookie = login("admin-json", "admin-json");
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .contentType(ContentType.URLENC).formParam("name", "react-admin-user")
+                .formParam("email", "react-admin-user@mnemosyne-systems.ai").formParam("type", User.TYPE_USER)
+                .formParam("password", "secret").post("/users").then().statusCode(200)
+                .body("redirectTo", Matchers.equalTo("/users"));
+        User createdUser = User.find("email", "react-admin-user@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(createdUser);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .multiPart("name", "React Redirect Category").multiPart("description", "Redirect body")
+                .multiPart("isDefault", "false").post("/categories").then().statusCode(200)
+                .body("redirectTo", Matchers.equalTo("/categories"));
+        Category category = Category.find("name", "React Redirect Category").firstResult();
+        Assertions.assertNotNull(category);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .post("/categories/" + category.id + "/delete").then().statusCode(200)
+                .body("redirectTo", Matchers.equalTo("/categories"));
+    }
+
+    @Test
+    void adminCannotDeleteCompanySuperuserWithoutReassignment() {
+        ensureUser("admin-delete", "admin-delete@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin-delete");
+        ensureUser("delete-target", "delete-target@mnemosyne-systems.ai", User.TYPE_USER, "delete-target");
+        String cookie = login("admin-delete", "admin-delete");
+        Long companyId = ensureCompany("Delete User Co");
+        Long targetUserId = prepareReferencedUserForDelete(companyId, "delete-target@mnemosyne-systems.ai", true);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .post("/user/" + targetUserId + "/delete").then().statusCode(400);
+
+        Assertions.assertNotNull(refreshedUser(targetUserId));
+        Company company = refreshedCompany(companyId);
+        Assertions.assertNotNull(company);
+        Assertions.assertNotNull(company.superuser);
+        Assertions.assertEquals(targetUserId, company.superuser.id);
+    }
+
+    @Test
+    void adminCanDeleteReferencedNonSuperuserWithoutServerError() {
+        ensureUser("admin-delete-2", "admin-delete-2@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin-delete-2");
+        ensureUser("delete-target-2", "delete-target-2@mnemosyne-systems.ai", User.TYPE_USER, "delete-target-2");
+        String cookie = login("admin-delete-2", "admin-delete-2");
+        Long companyId = ensureCompany("Delete User Co 2");
+        Long targetUserId = prepareReferencedUserForDelete(companyId, "delete-target-2@mnemosyne-systems.ai", false);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .post("/user/" + targetUserId + "/delete").then().statusCode(303)
+                .header("Location", Matchers.endsWith("/users"));
+
+        Assertions.assertNull(refreshedUser(targetUserId));
+        Assertions.assertFalse(companyHasUser(companyId, "delete-target-2@mnemosyne-systems.ai"));
+        Assertions.assertTrue(deleteReferencesCleared("delete-target-2@mnemosyne-systems.ai"));
+    }
+
+    @Transactional
+    Long prepareReferencedUserForDelete(Long companyId, String email, boolean assignAsSuperuser) {
+        Company company = Company.findById(companyId);
+        User user = User.find("email", email).firstResult();
+        Assertions.assertNotNull(company);
+        Assertions.assertNotNull(user);
+        if (company.users.stream().noneMatch(existing -> existing.id != null && existing.id.equals(user.id))) {
+            company.users.add(user);
+        }
+        if (assignAsSuperuser) {
+            company.superuser = user;
+        }
+
+        Ticket ticket = new Ticket();
+        ticket.name = Ticket.nextName(company);
+        ticket.status = "Open";
+        ticket.company = company;
+        ticket.requester = user;
+        ticket.supportUsers.add(user);
+        ticket.tamUsers.add(user);
+        ticket.persist();
+
+        Message message = new Message();
+        message.ticket = ticket;
+        message.body = "Delete target message";
+        message.date = java.time.LocalDateTime.now();
+        message.author = user;
+        message.persist();
+
+        return user.id;
+    }
+
+    @Transactional
+    boolean deleteReferencesCleared(String email) {
+        long requesterCount = Ticket.count("requester.email", email);
+        long messageAuthorCount = Message.count("author.email", email);
+        long supportCount = Ticket.count("select distinct t from Ticket t join t.supportUsers u where u.email = ?1",
+                email);
+        long tamCount = Ticket.count("select distinct t from Ticket t join t.tamUsers u where u.email = ?1", email);
+        return requesterCount == 0 && messageAuthorCount == 0 && supportCount == 0 && tamCount == 0;
+    }
+
 }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/SuperuserAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/SuperuserAccessTest.java
@@ -178,4 +178,31 @@ class SuperuserAccessTest extends AccessTestSupport {
                 .body("navigation.href", Matchers.hasItem("/superuser/tickets"));
     }
 
+    @Test
+    void reactSuperuserMutationsReturnJsonRedirects() {
+        ensureUser("superuser-json", "superuser-json@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser-json");
+        ensureDefaultCategories();
+        Long companyId = ensureCompany("Superuser Json Co");
+        ensureCompanyUsers(companyId, "superuser-json@mnemosyne-systems.ai");
+        String cookie = login("superuser-json", "superuser-json");
+        Entitlement entitlement = ensureEntitlement("Superuser Json Entitlement", "Superuser json detail");
+        Version version = ensureVersion(entitlement, "11.0.0", java.time.LocalDate.of(2026, 3, 1));
+        CompanyEntitlement entry = ensureCompanyEntitlement(companyId, entitlement);
+        Assertions.assertNotNull(entry);
+        Assertions.assertNotNull(version);
+
+        String redirectTo = RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .header("X-Billetsys-Client", "react").multiPart("status", "Open")
+                .multiPart("message", "Superuser json redirect create").multiPart("companyId", companyId)
+                .multiPart("companyEntitlementId", entry.id).multiPart("categoryId", Category.findDefault().id)
+                .multiPart("affectsVersionId", version.id).post("/superuser/tickets").then().statusCode(200)
+                .body("redirectTo", Matchers.matchesPattern("/superuser/tickets/\\d+")).extract().path("redirectTo");
+        Long createdTicketId = Long.valueOf(redirectTo.substring(redirectTo.lastIndexOf('/') + 1));
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .contentType(ContentType.URLENC).formParam("affectsVersionId", version.id)
+                .post("/superuser/tickets/" + createdTicketId).then().statusCode(200)
+                .body("redirectTo", Matchers.equalTo("/superuser/tickets/" + createdTicketId));
+    }
+
 }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/SupportAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/SupportAccessTest.java
@@ -844,4 +844,36 @@ class SupportAccessTest extends AccessTestSupport {
         Assertions.assertEquals("Closed", ticketEmailService.computeEffectiveStatus(ticket, "Closed"));
     }
 
+    @Test
+    void reactSupportMutationsReturnJsonRedirects() {
+        ensureUser("support-json", "support-json@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support-json");
+        ensureDefaultCategories();
+        String cookie = login("support-json", "support-json");
+        Long companyId = ensureCompany("Support Json Co");
+        Company company = Company.findById(companyId);
+        Entitlement entitlement = ensureEntitlement("Support Json Entitlement", "Support json detail");
+        Version version = ensureVersion(entitlement, "8.0.0", java.time.LocalDate.of(2026, 1, 1));
+        CompanyEntitlement entry = ensureCompanyEntitlement(companyId, entitlement);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .multiPart("status", "Open").multiPart("message", "Support json redirect create")
+                .multiPart("companyId", company.id).multiPart("companyEntitlementId", entry.id)
+                .multiPart("categoryId", Category.findDefault().id).multiPart("affectsVersionId", version.id)
+                .post("/support/tickets").then().statusCode(200)
+                .body("redirectTo", Matchers.matchesPattern("/support/tickets/\\d+"));
+
+        Ticket createdTicket = findMessageByBody("Support json redirect create").ticket;
+        Assertions.assertNotNull(createdTicket);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .contentType(ContentType.URLENC).formParam("status", "Assigned").formParam("companyId", company.id)
+                .formParam("companyEntitlementId", entry.id).formParam("categoryId", Category.findDefault().id)
+                .formParam("affectsVersionId", version.id).post("/support/tickets/" + createdTicket.id).then()
+                .statusCode(200).body("redirectTo", Matchers.equalTo("/support/tickets/" + createdTicket.id));
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .post("/support/tickets/" + createdTicket.id + "/assign").then().statusCode(200)
+                .body("redirectTo", Matchers.equalTo("/support/tickets/" + createdTicket.id));
+    }
+
 }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/UserAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/UserAccessTest.java
@@ -209,4 +209,31 @@ class UserAccessTest extends AccessTestSupport {
                 .body("attachments.downloadPath", Matchers.hasItem("/attachments/" + attachment.id + "/data"));
     }
 
+    @Test
+    void reactUserMutationsReturnJsonRedirects() {
+        ensureUser("user-json", "user-json@mnemosyne-systems.ai", User.TYPE_USER, "user-json");
+        ensureDefaultCategories();
+        String cookie = login("user-json", "user-json");
+        Long companyId = ensureCompany("User Json Co");
+        ensureCompanyUsers(companyId, "user-json@mnemosyne-systems.ai");
+        Entitlement entitlement = ensureEntitlement("User Json Entitlement", "User json detail");
+        Version version = ensureVersion(entitlement, "10.0.0", java.time.LocalDate.of(2026, 2, 1));
+        CompanyEntitlement entry = ensureCompanyEntitlement(companyId, entitlement);
+        Assertions.assertNotNull(entry);
+        Assertions.assertNotNull(version);
+
+        String redirectTo = RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .header("X-Billetsys-Client", "react").multiPart("status", "Open")
+                .multiPart("message", "User json redirect create").multiPart("companyId", companyId)
+                .multiPart("companyEntitlementId", entry.id).multiPart("categoryId", Category.findDefault().id)
+                .multiPart("affectsVersionId", version.id).post("/user/tickets").then().statusCode(200)
+                .body("redirectTo", Matchers.matchesPattern("/user/tickets/\\d+")).extract().path("redirectTo");
+        Long createdTicketId = Long.valueOf(redirectTo.substring(redirectTo.lastIndexOf('/') + 1));
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
+                .contentType(ContentType.URLENC).formParam("affectsVersionId", version.id)
+                .post("/user/tickets/" + createdTicketId).then().statusCode(200)
+                .body("redirectTo", Matchers.equalTo("/tickets/" + createdTicketId));
+    }
+
 }

--- a/src/frontend/src/pages/ArticleDetailPage.tsx
+++ b/src/frontend/src/pages/ArticleDetailPage.tsx
@@ -12,7 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import useJson from '../hooks/useJson';
 import DataState from '../components/common/DataState';
 import MarkdownContent from '../components/markdown/MarkdownContent';
-import { SmartLink } from '../utils/routing';
+import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import { postForm } from '../utils/api';
 import type { SessionPageProps } from '../types/app';
 import type { ArticleRecord } from '../types/domain';
@@ -34,8 +34,8 @@ function DeleteArticleButton({ articleId, label = 'Delete article' }: DeleteArti
     setDeleting(true);
     setError('');
     try {
-      await postForm(`/articles/${articleId}/delete`, []);
-      navigate('/articles');
+      const response = await postForm(`/articles/${articleId}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, '/articles'));
     } catch (submitError: unknown) {
       setDeleting(false);
       setError(submitError instanceof Error ? submitError.message : 'Unable to delete article.');

--- a/src/frontend/src/pages/ArticleFormPage.tsx
+++ b/src/frontend/src/pages/ArticleFormPage.tsx
@@ -14,6 +14,7 @@ import DataState from '../components/common/DataState';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import AttachmentPicker from '../components/common/AttachmentPicker';
 import { postMultipart } from '../utils/api';
+import { resolvePostRedirectPath } from '../utils/routing';
 import { DeleteArticleButton } from './ArticleDetailPage';
 import type { FormMode, SessionPageProps } from '../types/app';
 import type { ArticleRecord } from '../types/domain';
@@ -65,13 +66,13 @@ export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageP
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postMultipart(isEdit ? `/articles/${id}` : '/articles', [
+      const response = await postMultipart(isEdit ? `/articles/${id}` : '/articles', [
         ['title', formState.title],
         ['tags', formState.tags],
         ['body', formState.body],
         ...files.map((file): ['attachments', File] => ['attachments', file])
       ]);
-      navigate(isEdit && id ? `/articles/${id}` : '/articles');
+      navigate(await resolvePostRedirectPath(response, isEdit && id ? `/articles/${id}` : '/articles'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save article.' });
       return;

--- a/src/frontend/src/pages/CategoryFormPage.tsx
+++ b/src/frontend/src/pages/CategoryFormPage.tsx
@@ -13,6 +13,7 @@ import useJson from '../hooks/useJson';
 import DataState from '../components/common/DataState';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import { postForm, postMultipart } from '../utils/api';
+import { resolvePostRedirectPath } from '../utils/routing';
 import type { FormMode, SessionPageProps } from '../types/app';
 import type { CategoryRecord } from '../types/domain';
 
@@ -62,12 +63,12 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postMultipart(isEdit ? `/categories/${id}` : '/categories', [
+      const response = await postMultipart(isEdit ? `/categories/${id}` : '/categories', [
         ['name', formState.name],
         ['description', formState.description],
         ['isDefault', String(formState.isDefault)]
       ]);
-      navigate(isEdit && id ? `/categories/${id}` : '/categories');
+      navigate(await resolvePostRedirectPath(response, isEdit && id ? `/categories/${id}` : '/categories'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save category.' });
       return;
@@ -81,8 +82,8 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/categories/${id}/delete`, []);
-      navigate('/categories');
+      const response = await postForm(`/categories/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, '/categories'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete category.' });
       return;

--- a/src/frontend/src/pages/CompanyFormPage.tsx
+++ b/src/frontend/src/pages/CompanyFormPage.tsx
@@ -225,8 +225,8 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/companies/${id}/delete`, []);
-      navigate('/companies');
+      const response = await postForm(`/companies/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, '/companies'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete company.' });
       return;

--- a/src/frontend/src/pages/DirectoryUserDetailPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserDetailPage.tsx
@@ -11,7 +11,7 @@ import DataState from '../components/common/DataState';
 import { UserDetailCard } from '../components/users/UserProfileSections';
 import useJson from '../hooks/useJson';
 import { postForm } from '../utils/api';
-import { resolveClientPath, SmartLink } from '../utils/routing';
+import { resolveClientPath, resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import type { MouseEvent } from 'react';
 import type { SessionPageProps } from '../types/app';
 import type { DirectoryUserDetail } from '../types/domain';
@@ -40,8 +40,8 @@ export default function DirectoryUserDetailPage({ sessionState, apiBase, backFal
       return;
     }
     try {
-      await postForm(detail.deletePath, []);
-      navigate(resolveClientPath(detail.backPath, backFallback));
+      const response = await postForm(detail.deletePath, []);
+      navigate(await resolvePostRedirectPath(response, resolveClientPath(detail.backPath, backFallback)));
     } catch (error: unknown) {
       window.alert(error instanceof Error ? error.message : 'Unable to delete user.');
     }

--- a/src/frontend/src/pages/DirectoryUserFormPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserFormPage.tsx
@@ -14,7 +14,7 @@ import useJson from '../hooks/useJson';
 import { postForm } from '../utils/api';
 import { createDirectoryUserFormState } from '../utils/forms';
 import { toQueryString } from '../utils/formatting';
-import { resolveClientPath, SmartLink } from '../utils/routing';
+import { resolveClientPath, resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import type { SessionPageProps } from '../types/app';
 import type { CountryOption, DirectoryUserBootstrap, NamedEntity, TimezoneOption } from '../types/domain';
 import type { DirectoryUserFormState } from '../utils/forms';
@@ -79,7 +79,7 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(bootstrap.submitPath, [
+      const response = await postForm(bootstrap.submitPath, [
         ['name', formState.name],
         ['fullName', formState.fullName],
         ['email', formState.email],
@@ -92,7 +92,7 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
         ['companyId', formState.companyId],
         ['password', formState.password]
       ]);
-      navigate(resolveClientPath(bootstrap.cancelPath, navigateFallback));
+      navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save user.' });
       return;
@@ -106,8 +106,8 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/user/${id}/delete`, []);
-      navigate(resolveClientPath(bootstrap.cancelPath, navigateFallback));
+      const response = await postForm(`/user/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete user.' });
       return;

--- a/src/frontend/src/pages/EntitlementEditorPage.tsx
+++ b/src/frontend/src/pages/EntitlementEditorPage.tsx
@@ -13,6 +13,7 @@ import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
 import DataState from '../components/common/DataState';
 import { postForm } from '../utils/api';
+import { resolvePostRedirectPath } from '../utils/routing';
 import type { FormMode, SessionPageProps } from '../types/app';
 import type { EntitlementRecord, LevelRecord } from '../types/domain';
 import type { FormEntries } from '../utils/api';
@@ -143,8 +144,8 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
           ['versionDates', version.date]
         ])
       ];
-      await postForm(isEdit ? `/entitlements/${id}` : '/entitlements', entries);
-      navigate('/entitlements');
+      const response = await postForm(isEdit ? `/entitlements/${id}` : '/entitlements', entries);
+      navigate(await resolvePostRedirectPath(response, '/entitlements'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save entitlement.' });
       return;
@@ -158,8 +159,8 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/entitlements/${id}/delete`, []);
-      navigate('/entitlements');
+      const response = await postForm(`/entitlements/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, '/entitlements'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
       return;

--- a/src/frontend/src/pages/EntitlementFormPage.tsx
+++ b/src/frontend/src/pages/EntitlementFormPage.tsx
@@ -13,6 +13,7 @@ import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
 import DataState from '../components/common/DataState';
 import { postForm } from '../utils/api';
+import { resolvePostRedirectPath } from '../utils/routing';
 import type { FormMode, SessionPageProps } from '../types/app';
 import type { EntitlementRecord, LevelRecord } from '../types/domain';
 import type { FormEntries } from '../utils/api';
@@ -143,8 +144,8 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
           ['versionDates', version.date]
         ])
       ];
-      await postForm(isEdit ? `/entitlements/${id}` : '/entitlements', entries);
-      navigate('/entitlements');
+      const response = await postForm(isEdit ? `/entitlements/${id}` : '/entitlements', entries);
+      navigate(await resolvePostRedirectPath(response, '/entitlements'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save entitlement.' });
       return;
@@ -158,8 +159,8 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/entitlements/${id}/delete`, []);
-      navigate('/entitlements');
+      const response = await postForm(`/entitlements/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, '/entitlements'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
       return;

--- a/src/frontend/src/pages/LevelFormPage.tsx
+++ b/src/frontend/src/pages/LevelFormPage.tsx
@@ -15,6 +15,7 @@ import useJson from '../hooks/useJson';
 import { PATHS } from '../routes/paths';
 import { postForm } from '../utils/api';
 import { levelColorMarker } from '../utils/formatting';
+import { resolvePostRedirectPath } from '../utils/routing';
 import type { FormMode, SessionPageProps } from '../types/app';
 import type { CountryOption, LevelRecord, TimezoneOption } from '../types/domain';
 
@@ -99,7 +100,7 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(isEdit ? `${PATHS.levels}/${id}` : PATHS.levels, [
+      const response = await postForm(isEdit ? `${PATHS.levels}/${id}` : PATHS.levels, [
         ['name', formState.name],
         ['description', formState.description],
         ['level', formState.level],
@@ -111,7 +112,7 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
         ['countryId', formState.countryId],
         ['timezoneId', formState.timezoneId]
       ]);
-      navigate(PATHS.levels);
+      navigate(await resolvePostRedirectPath(response, PATHS.levels));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save level.' });
       return;
@@ -125,8 +126,8 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`${PATHS.levels}/${id}/delete`, []);
-      navigate(PATHS.levels);
+      const response = await postForm(`${PATHS.levels}/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, PATHS.levels));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete level.' });
       return;

--- a/src/frontend/src/pages/MessageFormPage.tsx
+++ b/src/frontend/src/pages/MessageFormPage.tsx
@@ -15,7 +15,7 @@ import useJson from '../hooks/useJson';
 import { postForm, postMultipart } from '../utils/api';
 import { toQueryString } from '../utils/formatting';
 import { PATHS } from '../routes/paths';
-import { SmartLink } from '../utils/routing';
+import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import type { SessionPageProps } from '../types/app';
 import type { MessageFormBootstrap } from '../types/domain';
 
@@ -57,13 +57,13 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postMultipart(bootstrap.submitPath, [
+      const response = await postMultipart(bootstrap.submitPath, [
         ['body', formState.body],
         ['date', formState.date],
         ['ticketId', formState.ticketId],
         ['attachments', formState.files]
       ]);
-      navigate(PATHS.messages);
+      navigate(await resolvePostRedirectPath(response, PATHS.messages));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save message.' });
       return;
@@ -77,8 +77,8 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/messages/${id}/delete`, []);
-      navigate(PATHS.messages);
+      const response = await postForm(`/messages/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, PATHS.messages));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete message.' });
       return;

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -8,7 +8,7 @@
 
 import type { ChangeEvent, FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
 import MarkdownContent from '../components/markdown/MarkdownContent';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
@@ -16,7 +16,7 @@ import { UserHoverLink, UserReferenceInlineList } from '../components/users/User
 import useJson from '../hooks/useJson';
 import { postForm } from '../utils/api';
 import { formatFileSize, toQueryString, versionLabel } from '../utils/formatting';
-import { SmartLink } from '../utils/routing';
+import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import type { SessionPageProps } from '../types/app';
 import type { AttachmentReference, MessageReference, NamedEntity, SupportTicketDetailRecord, VersionInfo } from '../types/domain';
 import type { SupportTicketDetailState } from '../types/forms';
@@ -37,6 +37,7 @@ export default function SupportTicketDetailPage({
 }: SupportTicketDetailPageProps) {
   const { id } = useParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const [refreshNonce, setRefreshNonce] = useState(0);
   const ticketState = useJson<SupportTicketDetailRecord>(id ? `${apiBase}/${id}${toQueryString({ refresh: refreshNonce })}` : null);
   const ticket = ticketState.data;
@@ -96,7 +97,7 @@ export default function SupportTicketDetailPage({
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(ticket.actionPath || `${apiBase}/${id || ''}`, [
+      const response = await postForm(ticket.actionPath || `${apiBase}/${id || ''}`, [
         ['status', formState.status],
         ['companyId', ticket.companyId],
         ['companyEntitlementId', ticket.companyEntitlementId],
@@ -107,7 +108,12 @@ export default function SupportTicketDetailPage({
       ], {
         headers: { 'X-Billetsys-Client': 'react' }
       });
-      setRefreshNonce(current => current + 1);
+      const redirectPath = await resolvePostRedirectPath(response, ticket.actionPath || `${apiBase}/${id || ''}`);
+      if (redirectPath !== location.pathname) {
+        navigate(redirectPath);
+      } else {
+        setRefreshNonce(current => current + 1);
+      }
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });
       return;

--- a/src/frontend/src/pages/TicketWorkbenchFormPage.tsx
+++ b/src/frontend/src/pages/TicketWorkbenchFormPage.tsx
@@ -13,7 +13,7 @@ import DataState from '../components/common/DataState';
 import useJson from '../hooks/useJson';
 import { postForm } from '../utils/api';
 import { toQueryString } from '../utils/formatting';
-import { SmartLink } from '../utils/routing';
+import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import type { SessionPageProps } from '../types/app';
 import type { CompanyEntitlementOption, NamedEntity, TicketWorkbenchBootstrap, VersionInfo } from '../types/domain';
 import type { TicketWorkbenchFormState } from '../types/forms';
@@ -79,7 +79,7 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(bootstrap.submitPath, [
+      const response = await postForm(bootstrap.submitPath, [
         ['status', formState.status],
         ['companyId', formState.companyId],
         ['companyEntitlementId', formState.companyEntitlementId],
@@ -88,7 +88,7 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
         ['affectsVersionId', formState.affectsVersionId],
         ['resolvedVersionId', formState.resolvedVersionId]
       ]);
-      navigate('/tickets');
+      navigate(await resolvePostRedirectPath(response, '/tickets'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });
       return;
@@ -102,8 +102,8 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
     }
     setSaveState({ saving: true, error: '' });
     try {
-      await postForm(`/tickets/${id}/delete`, []);
-      navigate('/tickets');
+      const response = await postForm(`/tickets/${id}/delete`, []);
+      navigate(await resolvePostRedirectPath(response, '/tickets'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete ticket.' });
       return;

--- a/src/frontend/src/utils/api.ts
+++ b/src/frontend/src/utils/api.ts
@@ -18,8 +18,16 @@ interface MultipartOptions {
   headers?: HeadersInit;
 }
 
+const inFlightMutationRequests = new Map<string, Promise<Response>>();
+
 export async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, { credentials: 'same-origin', cache: 'no-store' });
+  const response = await performRequest(url, {
+    credentials: 'same-origin',
+    cache: 'no-store',
+    headers: {
+      'X-Billetsys-Client': 'react'
+    }
+  });
   if (response.status === 401) {
     throw new Error('You need to sign in again.');
   }
@@ -36,16 +44,21 @@ export async function postForm(url: string, entries: FormEntries, options: FormO
   const body = new URLSearchParams();
   entries.forEach(([key, value]) => appendSearchValue(body, key, value));
 
-  const response = await fetch(url, {
+  const response = await performMutationRequest(url, {
     method: 'POST',
     credentials: 'same-origin',
+    redirect: 'manual',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      'X-Billetsys-Client': 'react',
       ...options.headers
     },
     body: body.toString()
   });
 
+  if (isSuccessfulRedirect(response)) {
+    return response;
+  }
   if (response.status === 401) {
     throw new Error('You need to sign in again.');
   }
@@ -63,13 +76,20 @@ export async function postMultipart(url: string, entries: FormEntries, options: 
   const body = new FormData();
   entries.forEach(([key, value]) => appendFormValue(body, key, value));
 
-  const response = await fetch(url, {
+  const response = await performMutationRequest(url, {
     method: 'POST',
     credentials: 'same-origin',
-    headers: options.headers,
+    redirect: 'manual',
+    headers: {
+      'X-Billetsys-Client': 'react',
+      ...options.headers
+    },
     body
   });
 
+  if (isSuccessfulRedirect(response)) {
+    return response;
+  }
   if (response.status === 401) {
     throw new Error('You need to sign in again.');
   }
@@ -103,6 +123,65 @@ function appendSearchValue(searchParams: URLSearchParams, key: string, value: Fo
     return;
   }
   searchParams.append(key, String(value));
+}
+
+async function performRequest(url: string, init: RequestInit): Promise<Response> {
+  return fetch(url, init);
+}
+
+async function performMutationRequest(url: string, init: RequestInit): Promise<Response> {
+  const requestKey = createMutationRequestKey(url, init);
+  const existingRequest = inFlightMutationRequests.get(requestKey);
+  if (existingRequest) {
+    return (await existingRequest).clone();
+  }
+
+  const requestPromise = performRequest(url, init);
+  inFlightMutationRequests.set(requestKey, requestPromise);
+
+  try {
+    return (await requestPromise).clone();
+  } finally {
+    inFlightMutationRequests.delete(requestKey);
+  }
+}
+
+function isSuccessfulRedirect(response: Response): boolean {
+  return response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400);
+}
+
+function createMutationRequestKey(url: string, init: RequestInit): string {
+  const method = (init.method || 'GET').toUpperCase();
+  const headers = normalizeHeaders(init.headers);
+  const body = normalizeBody(init.body);
+  return JSON.stringify({ method, url, headers, body });
+}
+
+function normalizeHeaders(headersInit?: HeadersInit): Array<[string, string]> {
+  if (!headersInit) {
+    return [];
+  }
+  return Array.from(new Headers(headersInit).entries()).sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+}
+
+function normalizeBody(body: BodyInit | null | undefined): string {
+  if (!body) {
+    return '';
+  }
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (body instanceof URLSearchParams) {
+    return body.toString();
+  }
+  if (body instanceof FormData) {
+    const normalizedEntries: Array<[string, string]> = [];
+    body.forEach((value, key) => {
+      normalizedEntries.push([key, value instanceof File ? `${value.name}:${value.size}:${value.type}` : value]);
+    });
+    return JSON.stringify(normalizedEntries);
+  }
+  return String(body);
 }
 
 function toErrorMessage(text: string, fallback: string): string {

--- a/src/frontend/src/utils/routing.tsx
+++ b/src/frontend/src/utils/routing.tsx
@@ -79,6 +79,18 @@ export async function resolvePostRedirectPath(response: Response, fallback: stri
     const payload = (await response.json()) as RedirectJsonPayload;
     return resolveClientPath(payload?.redirectTo, fallback);
   }
+  const location = response?.headers?.get('Location');
+  if (location) {
+    try {
+      const redirectUrl = new URL(location, window.location.origin);
+      if (redirectUrl.origin !== window.location.origin) {
+        return fallback;
+      }
+      return resolveClientPath(`${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`, fallback);
+    } catch {
+      return resolveClientPath(location, fallback);
+    }
+  }
   return resolveRedirectPath(response, fallback);
 }
 


### PR DESCRIPTION

### Fix React POST mutation routing and duplicate-submit issues across the app.

## Changes

- Added a shared backend redirect contract for React mutations: successful POSTs now return `200` JSON with `redirectTo`.
- Updated user, company, category, article, message, level, entitlement, ticket, support, and superuser mutation flows to use the shared redirect helper.
- Fixed frontend redirect handling to follow JSON redirects and safe same-origin `Location` headers.
- Preserved native fetch/network errors instead of masking them.
- Replaced broad global POST deduping with a per-page `useSubmissionGuard` hook to block duplicate save/delete clicks locally.
- Fixed admin user delete cleanup and blocked deleting a user who is still assigned as a company superuser.