### PR TITLE
[#87] Replace global POST deduping with per-page submit guards

### DIFF
--- a/src/frontend/src/hooks/useSubmissionGuard.ts
+++ b/src/frontend/src/hooks/useSubmissionGuard.ts
@@ -1,0 +1,26 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+import { useRef } from 'react';
+
+export default function useSubmissionGuard() {
+  const inFlightRef = useRef(false);
+
+  return {
+    tryEnter: () => {
+      if (inFlightRef.current) {
+        return false;
+      }
+      inFlightRef.current = true;
+      return true;
+    },
+    exit: () => {
+      inFlightRef.current = false;
+    }
+  };
+}

--- a/src/frontend/src/pages/ArticleDetailPage.tsx
+++ b/src/frontend/src/pages/ArticleDetailPage.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
 import MarkdownContent from '../components/markdown/MarkdownContent';
 import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
@@ -26,20 +27,23 @@ function DeleteArticleButton({ articleId, label = 'Delete article' }: DeleteArti
   const navigate = useNavigate();
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState('');
+  const submissionGuard = useSubmissionGuard();
 
   const remove = async () => {
-    if (!window.confirm('Delete this article?')) {
+    if (!window.confirm('Delete this article?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setDeleting(true);
-    setError('');
     try {
+      setDeleting(true);
+      setError('');
       const response = await postForm(`/articles/${articleId}/delete`, []);
       navigate(await resolvePostRedirectPath(response, '/articles'));
     } catch (submitError: unknown) {
       setDeleting(false);
       setError(submitError instanceof Error ? submitError.message : 'Unable to delete article.');
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setDeleting(false);
   };

--- a/src/frontend/src/pages/ArticleFormPage.tsx
+++ b/src/frontend/src/pages/ArticleFormPage.tsx
@@ -10,6 +10,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import AttachmentPicker from '../components/common/AttachmentPicker';
@@ -38,6 +39,7 @@ export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageP
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
   const [files, setFiles] = useState<File[]>([]);
   const bodyInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const submissionGuard = useSubmissionGuard();
   const isEdit = mode === 'edit';
 
   const updateFormState = (field: keyof ArticleFormState, value: string) => {
@@ -61,11 +63,11 @@ export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageP
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postMultipart(isEdit ? `/articles/${id}` : '/articles', [
         ['title', formState.title],
         ['tags', formState.tags],
@@ -76,6 +78,8 @@ export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageP
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save article.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/CategoryFormPage.tsx
+++ b/src/frontend/src/pages/CategoryFormPage.tsx
@@ -10,6 +10,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import { postForm, postMultipart } from '../utils/api';
@@ -35,6 +36,7 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
   const [formState, setFormState] = useState<CategoryFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
   const descriptionInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const submissionGuard = useSubmissionGuard();
   const isEdit = mode === 'edit';
 
   const updateFormState = <K extends keyof CategoryFormState>(field: K, value: CategoryFormState[K]) => {
@@ -58,11 +60,11 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postMultipart(isEdit ? `/categories/${id}` : '/categories', [
         ['name', formState.name],
         ['description', formState.description],
@@ -72,21 +74,25 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save category.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteCategory = async () => {
-    if (!id || !window.confirm('Delete this category?')) {
+    if (!id || !window.confirm('Delete this category?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/categories/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, '/categories'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete category.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/CompanyFormPage.tsx
+++ b/src/frontend/src/pages/CompanyFormPage.tsx
@@ -10,6 +10,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
 import { SmartLink, resolvePostRedirectPath } from '../utils/routing';
 import { postForm } from '../utils/api';
@@ -56,6 +57,7 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
   const company = companyState.data;
   const [formState, setFormState] = useState<CompanyFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const isEdit = mode === 'edit';
 
   useEffect(() => {
@@ -165,10 +167,9 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     const entries: BrowserFormEntries = [
       ['name', formState.name],
       ['address1', formState.address1],
@@ -189,6 +190,7 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
       ])
     ];
     try {
+      setSaveState({ saving: true, error: '' });
       if (isEdit) {
         entries.push(['superuserId', formState.superuserId]);
       } else {
@@ -210,26 +212,31 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
     } catch (error: unknown) {
       if (isNetworkRequestError(error)) {
         setSaveState({ saving: false, error: '' });
+        submissionGuard.exit();
         submitBrowserForm(isEdit ? `/companies/${id}` : '/companies', entries);
         return;
       }
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save company.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteCompany = async () => {
-    if (!id || !window.confirm('Delete this company?')) {
+    if (!id || !window.confirm('Delete this company?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/companies/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, '/companies'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete company.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/DirectoryUserDetailPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserDetailPage.tsx
@@ -10,6 +10,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
 import { UserDetailCard } from '../components/users/UserProfileSections';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postForm } from '../utils/api';
 import { resolveClientPath, resolvePostRedirectPath, SmartLink } from '../utils/routing';
 import type { MouseEvent } from 'react';
@@ -27,6 +28,7 @@ export default function DirectoryUserDetailPage({ sessionState, apiBase, backFal
   const detailState = useJson<DirectoryUserDetail>(id ? `${apiBase}/${id}` : null);
   const detail = detailState.data;
   const resolvedBackHref = detail?.backPath || backFallback;
+  const submissionGuard = useSubmissionGuard();
 
   const handleBackClick = (event: MouseEvent<HTMLAnchorElement>) => {
     if (window.history.length > 1) {
@@ -36,7 +38,7 @@ export default function DirectoryUserDetailPage({ sessionState, apiBase, backFal
   };
 
   const deleteUser = async () => {
-    if (!detail?.deletePath || !window.confirm('Delete this user?')) {
+    if (!detail?.deletePath || !window.confirm('Delete this user?') || !submissionGuard.tryEnter()) {
       return;
     }
     try {
@@ -44,6 +46,8 @@ export default function DirectoryUserDetailPage({ sessionState, apiBase, backFal
       navigate(await resolvePostRedirectPath(response, resolveClientPath(detail.backPath, backFallback)));
     } catch (error: unknown) {
       window.alert(error instanceof Error ? error.message : 'Unable to delete user.');
+    } finally {
+      submissionGuard.exit();
     }
   };
 

--- a/src/frontend/src/pages/DirectoryUserFormPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserFormPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postForm } from '../utils/api';
 import { createDirectoryUserFormState } from '../utils/forms';
 import { toQueryString } from '../utils/formatting';
@@ -39,6 +40,7 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
   const isAdminCreate = !isEdit && bootstrapBase === '/api/admin/users/bootstrap';
   const [formState, setFormState] = useState<DirectoryUserFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const selectedCountryId = formState?.countryId || '';
   const bootstrapState = useJson<DirectoryUserBootstrap>(
     `${bootstrapBase}${toQueryString({
@@ -74,11 +76,11 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState || !bootstrap) {
+    if (!formState || !bootstrap || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(bootstrap.submitPath, [
         ['name', formState.name],
         ['fullName', formState.fullName],
@@ -96,21 +98,25 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save user.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteUser = async () => {
-    if (!id || !bootstrap?.submitPath?.startsWith('/user/') || !window.confirm('Delete this user?')) {
+    if (!id || !bootstrap?.submitPath?.startsWith('/user/') || !window.confirm('Delete this user?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/user/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete user.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/EntitlementEditorPage.tsx
+++ b/src/frontend/src/pages/EntitlementEditorPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
 import { postForm } from '../utils/api';
 import { resolvePostRedirectPath } from '../utils/routing';
@@ -47,6 +48,7 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
   const entitlement = entitlementState.data;
   const [formState, setFormState] = useState<EntitlementFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const isEdit = mode === 'edit';
 
   const updateFormState = <K extends keyof EntitlementFormState>(field: K, value: EntitlementFormState[K]) => {
@@ -129,11 +131,11 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const entries: FormEntries = [
         ['name', formState.name],
         ['description', formState.description],
@@ -149,21 +151,25 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save entitlement.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteEntitlement = async () => {
-    if (!id || !window.confirm('Delete this entitlement?')) {
+    if (!id || !window.confirm('Delete this entitlement?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/entitlements/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, '/entitlements'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/EntitlementFormPage.tsx
+++ b/src/frontend/src/pages/EntitlementFormPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
 import { postForm } from '../utils/api';
 import { resolvePostRedirectPath } from '../utils/routing';
@@ -47,6 +48,7 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
   const entitlement = entitlementState.data;
   const [formState, setFormState] = useState<EntitlementFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const isEdit = mode === 'edit';
 
   const updateFormState = <K extends keyof EntitlementFormState>(field: K, value: EntitlementFormState[K]) => {
@@ -129,11 +131,11 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const entries: FormEntries = [
         ['name', formState.name],
         ['description', formState.description],
@@ -149,21 +151,25 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save entitlement.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteEntitlement = async () => {
-    if (!id || !window.confirm('Delete this entitlement?')) {
+    if (!id || !window.confirm('Delete this entitlement?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/entitlements/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, '/entitlements'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/LevelFormPage.tsx
+++ b/src/frontend/src/pages/LevelFormPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { PATHS } from '../routes/paths';
 import { postForm } from '../utils/api';
 import { levelColorMarker } from '../utils/formatting';
@@ -67,6 +68,7 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
   const level = levelState.data;
   const [formState, setFormState] = useState<LevelFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const isEdit = mode === 'edit';
 
   useEffect(() => {
@@ -95,11 +97,11 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(isEdit ? `${PATHS.levels}/${id}` : PATHS.levels, [
         ['name', formState.name],
         ['description', formState.description],
@@ -116,21 +118,25 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save level.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteLevel = async () => {
-    if (!id || !window.confirm('Delete this level?')) {
+    if (!id || !window.confirm('Delete this level?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`${PATHS.levels}/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, PATHS.levels));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete level.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/MessageFormPage.tsx
+++ b/src/frontend/src/pages/MessageFormPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import AttachmentPicker from '../components/common/AttachmentPicker';
 import DataState from '../components/common/DataState';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postForm, postMultipart } from '../utils/api';
 import { toQueryString } from '../utils/formatting';
 import { PATHS } from '../routes/paths';
@@ -33,6 +34,7 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
   const bootstrap = bootstrapState.data;
   const [formState, setFormState] = useState<MessageFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
 
   const updateFormState = <K extends keyof MessageFormState>(field: K, value: MessageFormState[K]) => {
     setFormState(current => (current ? { ...current, [field]: value } : current));
@@ -52,11 +54,11 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!bootstrap || !formState) {
+    if (!bootstrap || !formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postMultipart(bootstrap.submitPath, [
         ['body', formState.body],
         ['date', formState.date],
@@ -67,21 +69,25 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save message.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteMessage = async () => {
-    if (!id || !window.confirm('Delete this message?')) {
+    if (!id || !window.confirm('Delete this message?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/messages/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, PATHS.messages));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete message.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/SupportTicketCreatePage.tsx
+++ b/src/frontend/src/pages/SupportTicketCreatePage.tsx
@@ -13,6 +13,7 @@ import AttachmentPicker from '../components/common/AttachmentPicker';
 import DataState from '../components/common/DataState';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postMultipart } from '../utils/api';
 import { toQueryString } from '../utils/formatting';
 import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
@@ -57,6 +58,7 @@ export default function SupportTicketCreatePage({
   const [files, setFiles] = useState<File[]>([]);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const submissionGuard = useSubmissionGuard();
   const showFixedCompany = sessionState.data?.role === 'superuser';
   const compactCreateHeader = apiBase === '/api/superuser/tickets/bootstrap';
 
@@ -101,11 +103,11 @@ export default function SupportTicketCreatePage({
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState) {
+    if (!formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const entries: FormEntries = [
         ['status', 'Open'],
         ['message', formState.message],
@@ -126,6 +128,8 @@ export default function SupportTicketCreatePage({
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to create ticket.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -14,6 +14,7 @@ import MarkdownContent from '../components/markdown/MarkdownContent';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import { UserHoverLink, UserReferenceInlineList } from '../components/users/UserComponents';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postForm } from '../utils/api';
 import { formatFileSize, toQueryString, versionLabel } from '../utils/formatting';
 import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
@@ -43,6 +44,7 @@ export default function SupportTicketDetailPage({
   const ticket = ticketState.data;
   const [formState, setFormState] = useState<SupportTicketDetailState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const [replyState] = useState({ saving: false, error: '' });
   const [replyBody, setReplyBody] = useState('');
   const [files, setFiles] = useState<File[]>([]);
@@ -92,11 +94,11 @@ export default function SupportTicketDetailPage({
 
   const saveTicket = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!ticket || !formState) {
+    if (!ticket || !formState || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(ticket.actionPath || `${apiBase}/${id || ''}`, [
         ['status', formState.status],
         ['companyId', ticket.companyId],
@@ -117,6 +119,8 @@ export default function SupportTicketDetailPage({
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/pages/TicketWorkbenchFormPage.tsx
+++ b/src/frontend/src/pages/TicketWorkbenchFormPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
 import useJson from '../hooks/useJson';
+import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postForm } from '../utils/api';
 import { toQueryString } from '../utils/formatting';
 import { resolvePostRedirectPath, SmartLink } from '../utils/routing';
@@ -27,6 +28,7 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
   const requestedCompanyId = query.get('companyId') || '';
   const [formState, setFormState] = useState<TicketWorkbenchFormState | null>(null);
   const [saveState, setSaveState] = useState({ saving: false, error: '' });
+  const submissionGuard = useSubmissionGuard();
   const bootstrapState = useJson<TicketWorkbenchBootstrap>(
     `/api/ticket-workbench/bootstrap${toQueryString({ ticketId: id, companyId: formState?.companyId || requestedCompanyId })}`
   );
@@ -74,11 +76,11 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!formState || !bootstrap) {
+    if (!formState || !bootstrap || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(bootstrap.submitPath, [
         ['status', formState.status],
         ['companyId', formState.companyId],
@@ -92,21 +94,25 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };
 
   const deleteTicket = async () => {
-    if (!id || !window.confirm('Delete this ticket?')) {
+    if (!id || !window.confirm('Delete this ticket?') || !submissionGuard.tryEnter()) {
       return;
     }
-    setSaveState({ saving: true, error: '' });
     try {
+      setSaveState({ saving: true, error: '' });
       const response = await postForm(`/tickets/${id}/delete`, []);
       navigate(await resolvePostRedirectPath(response, '/tickets'));
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete ticket.' });
       return;
+    } finally {
+      submissionGuard.exit();
     }
     setSaveState({ saving: false, error: '' });
   };

--- a/src/frontend/src/utils/api.ts
+++ b/src/frontend/src/utils/api.ts
@@ -18,8 +18,6 @@ interface MultipartOptions {
   headers?: HeadersInit;
 }
 
-const inFlightMutationRequests = new Map<string, Promise<Response>>();
-
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await performRequest(url, {
     credentials: 'same-origin',
@@ -44,7 +42,7 @@ export async function postForm(url: string, entries: FormEntries, options: FormO
   const body = new URLSearchParams();
   entries.forEach(([key, value]) => appendSearchValue(body, key, value));
 
-  const response = await performMutationRequest(url, {
+  const response = await performRequest(url, {
     method: 'POST',
     credentials: 'same-origin',
     redirect: 'manual',
@@ -76,7 +74,7 @@ export async function postMultipart(url: string, entries: FormEntries, options: 
   const body = new FormData();
   entries.forEach(([key, value]) => appendFormValue(body, key, value));
 
-  const response = await performMutationRequest(url, {
+  const response = await performRequest(url, {
     method: 'POST',
     credentials: 'same-origin',
     redirect: 'manual',
@@ -129,60 +127,10 @@ async function performRequest(url: string, init: RequestInit): Promise<Response>
   return fetch(url, init);
 }
 
-async function performMutationRequest(url: string, init: RequestInit): Promise<Response> {
-  const requestKey = createMutationRequestKey(url, init);
-  const existingRequest = inFlightMutationRequests.get(requestKey);
-  if (existingRequest) {
-    return (await existingRequest).clone();
-  }
-
-  const requestPromise = performRequest(url, init);
-  inFlightMutationRequests.set(requestKey, requestPromise);
-
-  try {
-    return (await requestPromise).clone();
-  } finally {
-    inFlightMutationRequests.delete(requestKey);
-  }
-}
-
 function isSuccessfulRedirect(response: Response): boolean {
   return response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400);
 }
 
-function createMutationRequestKey(url: string, init: RequestInit): string {
-  const method = (init.method || 'GET').toUpperCase();
-  const headers = normalizeHeaders(init.headers);
-  const body = normalizeBody(init.body);
-  return JSON.stringify({ method, url, headers, body });
-}
-
-function normalizeHeaders(headersInit?: HeadersInit): Array<[string, string]> {
-  if (!headersInit) {
-    return [];
-  }
-  return Array.from(new Headers(headersInit).entries()).sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
-}
-
-function normalizeBody(body: BodyInit | null | undefined): string {
-  if (!body) {
-    return '';
-  }
-  if (typeof body === 'string') {
-    return body;
-  }
-  if (body instanceof URLSearchParams) {
-    return body.toString();
-  }
-  if (body instanceof FormData) {
-    const normalizedEntries: Array<[string, string]> = [];
-    body.forEach((value, key) => {
-      normalizedEntries.push([key, value instanceof File ? `${value.name}:${value.size}:${value.type}` : value]);
-    });
-    return JSON.stringify(normalizedEntries);
-  }
-  return String(body);
-}
 
 function toErrorMessage(text: string, fallback: string): string {
   const trimmed = text.trim();


### PR DESCRIPTION
## Changes

- Added `useSubmissionGuard` to synchronously block duplicate save/delete actions at the UI handler level.
- Removed the broad in-flight POST coalescing logic from `src/frontend/src/utils/api.ts`.
- Applied to the React pages using `postForm` and `postMultipart`.