### PR TITLE
[#87] Add reusable global toast notifications for request feedback across the frontend

### DIFF
--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -21,6 +21,7 @@ import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
+import io.quarkus.hibernate.orm.panache.Panache;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.inject.Inject;
@@ -563,6 +564,10 @@ public class UserResource {
     }
 
     private void removeUserReferences(User user) {
+        if (user != null && user.id != null && hasPasswordResetTokenTable()) {
+            Panache.getEntityManager().createNativeQuery("delete from password_reset_tokens where user_id = ?1")
+                    .setParameter(1, user.id).executeUpdate();
+        }
         List<Company> companies = Company
                 .find("select distinct c from Company c left join c.users u where u = ?1", user).list();
         for (Company company : companies) {
@@ -586,6 +591,13 @@ public class UserResource {
         for (Message message : messages) {
             message.author = null;
         }
+    }
+
+    private boolean hasPasswordResetTokenTable() {
+        Number matches = (Number) Panache.getEntityManager().createNativeQuery(
+                "select count(*) from information_schema.tables where lower(table_name) = 'password_reset_tokens'")
+                .getSingleResult();
+        return matches != null && matches.longValue() > 0;
     }
 
     private void validateUserFields(String name, String email, String type, boolean requirePassword, String password) {

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import { ToastProvider } from './components/common/ToastProvider';
 import AppFooter from './components/layout/AppFooter';
 import AuthenticatedHeader from './components/layout/AuthenticatedHeader';
 import LoginHeader from './components/layout/LoginHeader';
@@ -27,13 +28,15 @@ function App() {
   }, [brandName]);
 
   return (
-    <div className={isLoginRoute ? 'login-shell' : 'app-shell'}>
-      {isLoginRoute ? <LoginHeader brandName={brandName} /> : <AuthenticatedHeader session={session} />}
-      <main className={isLoginRoute ? 'login-main' : 'app-main'}>
-        <AppRoutes sessionState={sessionState} />
-      </main>
-      <AppFooter className={isLoginRoute ? 'login-footer' : 'app-footer'} />
-    </div>
+    <ToastProvider>
+      <div className={isLoginRoute ? 'login-shell' : 'app-shell'}>
+        {isLoginRoute ? <LoginHeader brandName={brandName} /> : <AuthenticatedHeader session={session} />}
+        <main className={isLoginRoute ? 'login-main' : 'app-main'}>
+          <AppRoutes sessionState={sessionState} />
+        </main>
+        <AppFooter className={isLoginRoute ? 'login-footer' : 'app-footer'} />
+      </div>
+    </ToastProvider>
   );
 }
 

--- a/src/frontend/src/app.css
+++ b/src/frontend/src/app.css
@@ -505,6 +505,74 @@ pre code {
   font-weight: 600;
 }
 
+.toast-viewport {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 1000;
+  display: grid;
+  gap: 12px;
+  width: min(360px, calc(100vw - 32px));
+}
+
+.toast {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+  background: #fff;
+}
+
+.toast-success {
+  border-color: #b8e6c8;
+  background: #f3fcf6;
+}
+
+.toast-error {
+  border-color: #f0b9c2;
+  background: #fff5f6;
+}
+
+.toast-danger {
+  border-color: #e48d9c;
+  background: #fdecee;
+}
+
+.toast-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.toast-copy strong {
+  font-size: 0.95rem;
+}
+
+.toast-copy span {
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.toast-dismiss {
+  min-width: 32px;
+  min-height: 32px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--body-text);
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.toast-dismiss:hover {
+  background: #fff;
+}
+
 .section-header {
   display: flex;
   justify-content: space-between;
@@ -1643,6 +1711,12 @@ pre code {
 
   .markdown-panels {
     grid-template-columns: 1fr;
+  }
+
+  .toast-viewport {
+    right: 12px;
+    bottom: 12px;
+    width: calc(100vw - 24px);
   }
 
   .markdown-panel + .markdown-panel {

--- a/src/frontend/src/components/common/ToastProvider.tsx
+++ b/src/frontend/src/components/common/ToastProvider.tsx
@@ -1,0 +1,138 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+import type { ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const DEFAULT_TOAST_DURATION_MS = 4500;
+
+export type ToastVariant = 'success' | 'error' | 'danger';
+
+export interface ToastInput {
+  variant: ToastVariant;
+  message: string;
+  durationMs?: number;
+}
+
+interface ToastRecord extends ToastInput {
+  id: string;
+}
+
+interface ToastContextValue {
+  showToast: (toast: ToastInput) => void;
+  dismissToast: (id: string) => void;
+}
+
+interface ToastProviderProps {
+  children: ReactNode;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function buildToastNavigationState(toast: ToastInput, state?: unknown): Record<string, unknown> {
+  if (state && typeof state === 'object' && !Array.isArray(state)) {
+    return { ...(state as Record<string, unknown>), appToast: toast };
+  }
+  return { appToast: toast };
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const dismissToast = (id: string) => {
+    setToasts(current => current.filter(toast => toast.id !== id));
+  };
+
+  const showToast = (toast: ToastInput) => {
+    setToasts(current => [
+      ...current,
+      {
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        durationMs: toast.durationMs ?? DEFAULT_TOAST_DURATION_MS,
+        ...toast
+      }
+    ]);
+  };
+
+  useEffect(() => {
+    const locationState = location.state;
+    if (!locationState || typeof locationState !== 'object' || Array.isArray(locationState)) {
+      return;
+    }
+    const state = locationState as Record<string, unknown>;
+    const pendingToast = state.appToast;
+    if (!isToastInput(pendingToast)) {
+      return;
+    }
+
+    showToast(pendingToast);
+
+    const { appToast, ...nextState } = state;
+    navigate(`${location.pathname}${location.search}${location.hash}`, {
+      replace: true,
+      state: Object.keys(nextState).length > 0 ? nextState : null
+    });
+  }, [location.hash, location.key, location.pathname, location.search, location.state, navigate]);
+
+  return (
+    <ToastContext.Provider value={{ showToast, dismissToast }}>
+      {children}
+      <div className="toast-viewport" aria-live="polite" aria-atomic="true">
+        {toasts.map(toast => (
+          <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider.');
+  }
+  return context;
+}
+
+interface ToastItemProps {
+  toast: ToastRecord;
+  onDismiss: (id: string) => void;
+}
+
+function ToastItem({ toast, onDismiss }: ToastItemProps) {
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => onDismiss(toast.id), toast.durationMs ?? DEFAULT_TOAST_DURATION_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [onDismiss, toast.durationMs, toast.id]);
+
+  return (
+    <div className={`toast toast-${toast.variant}`} role="status">
+      <div className="toast-copy">
+        <strong>{toast.variant === 'success' ? 'Success' : toast.variant === 'danger' ? 'Deleted' : 'Error'}</strong>
+        <span>{toast.message}</span>
+      </div>
+      <button type="button" className="toast-dismiss" onClick={() => onDismiss(toast.id)} aria-label="Dismiss notification">
+        ×
+      </button>
+    </div>
+  );
+}
+
+function isToastInput(value: unknown): value is ToastInput {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Partial<ToastInput>;
+  return (
+    (candidate.variant === 'success' || candidate.variant === 'error' || candidate.variant === 'danger') &&
+    typeof candidate.message === 'string'
+  );
+}

--- a/src/frontend/src/pages/ArticleDetailPage.tsx
+++ b/src/frontend/src/pages/ArticleDetailPage.tsx
@@ -9,6 +9,7 @@
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
@@ -25,6 +26,7 @@ interface DeleteArticleButtonProps {
 
 function DeleteArticleButton({ articleId, label = 'Delete article' }: DeleteArticleButtonProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState('');
   const submissionGuard = useSubmissionGuard();
@@ -37,10 +39,19 @@ function DeleteArticleButton({ articleId, label = 'Delete article' }: DeleteArti
       setDeleting(true);
       setError('');
       const response = await postForm(`/articles/${articleId}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, '/articles'));
+      navigate(await resolvePostRedirectPath(response, '/articles'), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Article deleted.'
+        })
+      });
     } catch (submitError: unknown) {
       setDeleting(false);
       setError(submitError instanceof Error ? submitError.message : 'Unable to delete article.');
+      showToast({
+        variant: 'error',
+        message: submitError instanceof Error ? submitError.message : 'Unable to delete article.'
+      });
       return;
     } finally {
       submissionGuard.exit();
@@ -53,7 +64,6 @@ function DeleteArticleButton({ articleId, label = 'Delete article' }: DeleteArti
       <button type="button" className="secondary-button danger-button" onClick={remove} disabled={deleting}>
         {deleting ? 'Deleting...' : label}
       </button>
-      {error && <p className="error-text">{error}</p>}
     </>
   );
 }

--- a/src/frontend/src/pages/ArticleFormPage.tsx
+++ b/src/frontend/src/pages/ArticleFormPage.tsx
@@ -9,6 +9,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
@@ -32,6 +33,7 @@ interface ArticleFormPageProps extends SessionPageProps {
 
 export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const articleState = useJson<ArticleRecord>(mode === 'edit' && id ? `/api/articles/${id}` : '/api/articles/bootstrap');
   const article = articleState.data;
@@ -74,9 +76,15 @@ export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageP
         ['body', formState.body],
         ...files.map((file): ['attachments', File] => ['attachments', file])
       ]);
-      navigate(await resolvePostRedirectPath(response, isEdit && id ? `/articles/${id}` : '/articles'));
+      navigate(await resolvePostRedirectPath(response, isEdit && id ? `/articles/${id}` : '/articles'), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'Article updated successfully.' : 'Article created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save article.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save article.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -113,8 +121,6 @@ export default function ArticleFormPage({ sessionState, mode }: ArticleFormPageP
               </div>
 
               <AttachmentPicker files={files} onFilesChange={setFiles} existingAttachments={article.attachments || []} />
-
-              {saveState.error && <p className="error-text">{saveState.error}</p>}
 
               <div className={`button-row${isEdit ? ' button-row-split' : ' button-row-end'}`}>
                 {isEdit && article.id && article.canDelete && <DeleteArticleButton articleId={article.id} label="Delete" />}

--- a/src/frontend/src/pages/CategoryFormPage.tsx
+++ b/src/frontend/src/pages/CategoryFormPage.tsx
@@ -9,6 +9,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
@@ -30,6 +31,7 @@ interface CategoryFormPageProps extends SessionPageProps {
 
 export default function CategoryFormPage({ sessionState, mode }: CategoryFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const categoryState = useJson<CategoryRecord>(mode === 'edit' && id ? `/api/categories/${id}` : '/api/categories/bootstrap');
   const category = categoryState.data;
@@ -70,9 +72,15 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
         ['description', formState.description],
         ['isDefault', String(formState.isDefault)]
       ]);
-      navigate(await resolvePostRedirectPath(response, isEdit && id ? `/categories/${id}` : '/categories'));
+      navigate(await resolvePostRedirectPath(response, isEdit && id ? `/categories/${id}` : '/categories'), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'Category updated successfully.' : 'Category created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save category.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save category.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -87,9 +95,15 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/categories/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, '/categories'));
+      navigate(await resolvePostRedirectPath(response, '/categories'), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Category deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete category.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete category.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -128,8 +142,6 @@ export default function CategoryFormPage({ sessionState, mode }: CategoryFormPag
                   />
                 </label>
               </div>
-              {saveState.error && <p className="error-text">{saveState.error}</p>}
-
               <div className={`button-row${isEdit ? ' button-row-split' : ' button-row-end'}`}>
                 {isEdit && (
                   <button type="button" className="secondary-button danger-button" onClick={deleteCategory} disabled={saveState.saving}>

--- a/src/frontend/src/pages/CompanyFormPage.tsx
+++ b/src/frontend/src/pages/CompanyFormPage.tsx
@@ -9,6 +9,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import DataState from '../components/common/DataState';
@@ -52,6 +53,7 @@ const EMPTY_COMPANY_FORM_STATE: CompanyFormState = {
 
 export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const companyState = useJson<CompanyFormBootstrap>(mode === 'edit' && id ? `/api/companies/${id}` : '/api/companies/bootstrap');
   const company = companyState.data;
@@ -208,7 +210,12 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
       }
 
       const response = await postForm(isEdit ? `/companies/${id}` : '/companies', entries);
-      navigate(await resolvePostRedirectPath(response, '/companies'));
+      navigate(await resolvePostRedirectPath(response, '/companies'), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'Company updated successfully.' : 'Company created successfully.'
+        })
+      });
     } catch (error: unknown) {
       if (isNetworkRequestError(error)) {
         setSaveState({ saving: false, error: '' });
@@ -217,6 +224,7 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
         return;
       }
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save company.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save company.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -231,9 +239,15 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/companies/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, '/companies'));
+      navigate(await resolvePostRedirectPath(response, '/companies'), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Company deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete company.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete company.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -638,8 +652,6 @@ export default function CompanyFormPage({ sessionState, mode }: CompanyFormPageP
                 </div>
               </div>
             )}
-
-            {saveState.error && <p className="error-text">{saveState.error}</p>}
 
             <div className={`button-row${isEdit ? ' button-row-split' : ' button-row-end'}`}>
               {isEdit ? (

--- a/src/frontend/src/pages/DirectoryUserDetailPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserDetailPage.tsx
@@ -8,6 +8,7 @@
 
 import { useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import { UserDetailCard } from '../components/users/UserProfileSections';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
@@ -25,6 +26,7 @@ interface DirectoryUserDetailPageProps extends SessionPageProps {
 export default function DirectoryUserDetailPage({ sessionState, apiBase, backFallback }: DirectoryUserDetailPageProps) {
   const navigate = useNavigate();
   const { id } = useParams();
+  const { showToast } = useToast();
   const detailState = useJson<DirectoryUserDetail>(id ? `${apiBase}/${id}` : null);
   const detail = detailState.data;
   const resolvedBackHref = detail?.backPath || backFallback;
@@ -43,9 +45,17 @@ export default function DirectoryUserDetailPage({ sessionState, apiBase, backFal
     }
     try {
       const response = await postForm(detail.deletePath, []);
-      navigate(await resolvePostRedirectPath(response, resolveClientPath(detail.backPath, backFallback)));
+      navigate(await resolvePostRedirectPath(response, resolveClientPath(detail.backPath, backFallback)), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'User deleted.'
+        })
+      });
     } catch (error: unknown) {
-      window.alert(error instanceof Error ? error.message : 'Unable to delete user.');
+      showToast({
+        variant: 'error',
+        message: error instanceof Error ? error.message : 'Unable to delete user.'
+      });
     } finally {
       submissionGuard.exit();
     }

--- a/src/frontend/src/pages/DirectoryUserFormPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserFormPage.tsx
@@ -9,6 +9,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
@@ -32,6 +33,7 @@ interface UserTypeOption {
 
 export default function DirectoryUserFormPage({ sessionState, bootstrapBase, navigateFallback }: DirectoryUserFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const location = useLocation();
   const query = new URLSearchParams(location.search);
@@ -94,9 +96,15 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
         ['companyId', formState.companyId],
         ['password', formState.password]
       ]);
-      navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)));
+      navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'User updated successfully.' : 'User created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save user.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save user.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -111,9 +119,15 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/user/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)));
+      navigate(await resolvePostRedirectPath(response, resolveClientPath(bootstrap.cancelPath, navigateFallback)), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'User deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete user.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete user.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -243,8 +257,6 @@ export default function DirectoryUserFormPage({ sessionState, bootstrapBase, nav
                 </div>
               </div>
             </div>
-
-            {saveState.error && <p className="error-text">{saveState.error}</p>}
 
             <div className={`button-row${isAdminCreate ? ' button-row-end' : ''}`}>
               <button type="submit" className="primary-button" disabled={saveState.saving}>

--- a/src/frontend/src/pages/EntitlementEditorPage.tsx
+++ b/src/frontend/src/pages/EntitlementEditorPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import { postForm } from '../utils/api';
 import { resolvePostRedirectPath } from '../utils/routing';
@@ -43,6 +44,7 @@ interface EntitlementFormBootstrap extends EntitlementRecord {
 
 export default function EntitlementEditorPage({ sessionState, mode }: EntitlementFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const entitlementState = useJson<EntitlementFormBootstrap>(mode === 'edit' && id ? `/api/entitlements/${id}` : '/api/entitlements/bootstrap');
   const entitlement = entitlementState.data;
@@ -147,9 +149,15 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
         ])
       ];
       const response = await postForm(isEdit ? `/entitlements/${id}` : '/entitlements', entries);
-      navigate(await resolvePostRedirectPath(response, '/entitlements'));
+      navigate(await resolvePostRedirectPath(response, '/entitlements'), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'Entitlement updated successfully.' : 'Entitlement created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save entitlement.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save entitlement.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -164,9 +172,15 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/entitlements/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, '/entitlements'));
+      navigate(await resolvePostRedirectPath(response, '/entitlements'), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Entitlement deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -246,8 +260,6 @@ export default function EntitlementEditorPage({ sessionState, mode }: Entitlemen
                   ))}
                 </div>
               </section>
-
-              {saveState.error && <p className="error-text">{saveState.error}</p>}
 
               <div className="button-row button-row-end">
                 {isEdit && (

--- a/src/frontend/src/pages/EntitlementFormPage.tsx
+++ b/src/frontend/src/pages/EntitlementFormPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import { postForm } from '../utils/api';
 import { resolvePostRedirectPath } from '../utils/routing';
@@ -43,6 +44,7 @@ interface EntitlementFormBootstrap extends EntitlementRecord {
 
 export default function EntitlementFormPage({ sessionState, mode }: EntitlementFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const entitlementState = useJson<EntitlementFormBootstrap>(mode === 'edit' && id ? `/api/entitlements/${id}` : '/api/entitlements/bootstrap');
   const entitlement = entitlementState.data;
@@ -147,9 +149,15 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
         ])
       ];
       const response = await postForm(isEdit ? `/entitlements/${id}` : '/entitlements', entries);
-      navigate(await resolvePostRedirectPath(response, '/entitlements'));
+      navigate(await resolvePostRedirectPath(response, '/entitlements'), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'Entitlement updated successfully.' : 'Entitlement created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save entitlement.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save entitlement.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -164,9 +172,15 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/entitlements/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, '/entitlements'));
+      navigate(await resolvePostRedirectPath(response, '/entitlements'), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Entitlement deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete entitlement.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -246,8 +260,6 @@ export default function EntitlementFormPage({ sessionState, mode }: EntitlementF
                   ))}
                 </div>
               </section>
-
-              {saveState.error && <p className="error-text">{saveState.error}</p>}
 
               <div className="button-row button-row-end">
                 {isEdit && (

--- a/src/frontend/src/pages/LevelFormPage.tsx
+++ b/src/frontend/src/pages/LevelFormPage.tsx
@@ -10,6 +10,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import DataState from '../components/common/DataState';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
@@ -63,6 +64,7 @@ interface LevelFormPageProps extends SessionPageProps {
 
 export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const levelState = useJson<LevelFormBootstrap>(mode === 'edit' && id ? `/api/levels/${id}` : '/api/levels/bootstrap');
   const level = levelState.data;
@@ -114,9 +116,15 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
         ['countryId', formState.countryId],
         ['timezoneId', formState.timezoneId]
       ]);
-      navigate(await resolvePostRedirectPath(response, PATHS.levels));
+      navigate(await resolvePostRedirectPath(response, PATHS.levels), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: isEdit ? 'Level updated successfully.' : 'Level created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save level.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save level.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -131,9 +139,15 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`${PATHS.levels}/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, PATHS.levels));
+      navigate(await resolvePostRedirectPath(response, PATHS.levels), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Level deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete level.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete level.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -249,8 +263,6 @@ export default function LevelFormPage({ sessionState, mode }: LevelFormPageProps
                   <MarkdownEditor value={formState.description} onChange={value => updateFormState('description', value)} rows={10} required />
                 </label>
               </div>
-
-              {saveState.error && <p className="error-text">{saveState.error}</p>}
 
               <div className={`button-row${isEdit ? ' button-row-split' : ' button-row-end'}`}>
                 {isEdit && (

--- a/src/frontend/src/pages/MessageFormPage.tsx
+++ b/src/frontend/src/pages/MessageFormPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AttachmentPicker from '../components/common/AttachmentPicker';
 import DataState from '../components/common/DataState';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
 import { postForm, postMultipart } from '../utils/api';
@@ -29,6 +30,7 @@ interface MessageFormState {
 
 export default function MessageFormPage({ sessionState }: SessionPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const bootstrapState = useJson<MessageFormBootstrap>(`/api/messages/bootstrap${toQueryString({ messageId: id })}`);
   const bootstrap = bootstrapState.data;
@@ -65,9 +67,15 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
         ['ticketId', formState.ticketId],
         ['attachments', formState.files]
       ]);
-      navigate(await resolvePostRedirectPath(response, PATHS.messages));
+      navigate(await resolvePostRedirectPath(response, PATHS.messages), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: bootstrap.edit ? 'Message updated successfully.' : 'Message created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save message.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save message.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -82,9 +90,15 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/messages/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, PATHS.messages));
+      navigate(await resolvePostRedirectPath(response, PATHS.messages), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Message deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete message.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete message.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -130,8 +144,6 @@ export default function MessageFormPage({ sessionState }: SessionPageProps) {
             </div>
 
             <AttachmentPicker files={formState.files} onFilesChange={files => updateFormState('files', files)} existingAttachments={bootstrap.attachments || []} />
-
-            {saveState.error && <p className="error-text">{saveState.error}</p>}
 
             <div className="button-row">
               <button type="submit" className="primary-button" disabled={saveState.saving}>

--- a/src/frontend/src/pages/PasswordPage.tsx
+++ b/src/frontend/src/pages/PasswordPage.tsx
@@ -7,16 +7,24 @@
  */
 
 import type { FormEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import type { SessionPageProps } from '../types/app';
 
 export default function PasswordPage({ sessionState }: SessionPageProps) {
   const location = useLocation();
+  const { showToast } = useToast();
   const [formState, setFormState] = useState({ oldPassword: '', newPassword: '', confirmPassword: '' });
   const [saveState, setSaveState] = useState({ saving: false, error: '', saved: false });
   const routeError = new URLSearchParams(location.search).get('error') || '';
+
+  useEffect(() => {
+    if (routeError) {
+      showToast({ variant: 'error', message: routeError });
+    }
+  }, [routeError, showToast]);
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -33,6 +41,7 @@ export default function PasswordPage({ sessionState }: SessionPageProps) {
       }
       setFormState({ oldPassword: '', newPassword: '', confirmPassword: '' });
       setSaveState({ saving: false, error: '', saved: true });
+      showToast({ variant: 'success', message: 'Password updated successfully.' });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to update password.', saved: false });
     }
@@ -73,8 +82,6 @@ export default function PasswordPage({ sessionState }: SessionPageProps) {
               required
             />
           </label>
-          {(saveState.error || (!saveState.saved && routeError)) && <p className="error-text">{saveState.error || routeError}</p>}
-          {saveState.saved && <p className="success-text">Password updated.</p>}
           <div className="button-row">
             <button type="submit" className="primary-button" disabled={saveState.saving}>
               {saveState.saving ? 'Saving...' : 'Update'}

--- a/src/frontend/src/pages/ProfilePage.tsx
+++ b/src/frontend/src/pages/ProfilePage.tsx
@@ -9,6 +9,7 @@
 import type { ChangeEvent, FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import { UserLogoPreview } from '../components/users/UserProfileSections';
 import useJson from '../hooks/useJson';
@@ -30,6 +31,7 @@ interface ProfileFormState {
 
 export default function ProfilePage({ sessionState }: SessionPageProps) {
   const location = useLocation();
+  const { showToast } = useToast();
   const profileState = useJson<ProfileRecord>('/api/profile');
   const profile = profileState.data;
   const [formState, setFormState] = useState<ProfileFormState | null>(null);
@@ -53,6 +55,12 @@ export default function ProfilePage({ sessionState }: SessionPageProps) {
       });
     }
   }, [profile]);
+
+  useEffect(() => {
+    if (routeError) {
+      showToast({ variant: 'error', message: routeError });
+    }
+  }, [routeError, showToast]);
 
   const availableTimezones =
     profile?.timezones?.filter(timezone => !formState?.countryId || String(timezone.countryId) === formState.countryId) ||
@@ -133,6 +141,7 @@ export default function ProfilePage({ sessionState }: SessionPageProps) {
           : current
       );
       setSaveState({ saving: false, error: '', saved: true });
+      showToast({ variant: 'success', message: 'Profile saved successfully.' });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save profile.', saved: false });
     }
@@ -252,9 +261,6 @@ export default function ProfilePage({ sessionState }: SessionPageProps) {
                   </div>
                   <div className="detail-card-spacer" aria-hidden="true" />
                 </div>
-
-                {(saveState.error || (!saveState.saved && routeError)) && <p className="error-text">{saveState.error || routeError}</p>}
-                {saveState.saved && <p className="success-text">Profile saved.</p>}
 
                 <div className="button-row button-row-end">
                   <button type="submit" className="primary-button" disabled={saveState.saving}>

--- a/src/frontend/src/pages/SupportTicketCreatePage.tsx
+++ b/src/frontend/src/pages/SupportTicketCreatePage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AttachmentPicker from '../components/common/AttachmentPicker';
 import DataState from '../components/common/DataState';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
@@ -43,6 +44,7 @@ export default function SupportTicketCreatePage({
   hideEntitlementLevel = false
 }: SupportTicketCreatePageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [selectedCompanyId, setSelectedCompanyId] = useState('');
   const [selectedCompanyEntitlementId, setSelectedCompanyEntitlementId] = useState('');
   const bootstrapState = useJson<SupportTicketCreateBootstrap>(
@@ -123,9 +125,15 @@ export default function SupportTicketCreatePage({
           headers: { 'X-Billetsys-Client': 'react' }
         }
       );
-      navigate(await resolvePostRedirectPath(response, navigateTo));
+      navigate(await resolvePostRedirectPath(response, navigateTo), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: 'Support ticket created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to create ticket.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to create ticket.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -246,8 +254,6 @@ export default function SupportTicketCreatePage({
             </section>
 
             <AttachmentPicker files={files} onFilesChange={setFiles} />
-
-            {saveState.error && <p className="error-text">{saveState.error}</p>}
 
             <div className="button-row button-row-end">
               <button type="submit" className="primary-button" disabled={saveState.saving}>

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -9,6 +9,7 @@
 import type { ChangeEvent, FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import MarkdownContent from '../components/markdown/MarkdownContent';
 import MarkdownEditor from '../components/markdown/MarkdownEditor';
@@ -39,6 +40,7 @@ export default function SupportTicketDetailPage({
   const { id } = useParams();
   const location = useLocation();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [refreshNonce, setRefreshNonce] = useState(0);
   const ticketState = useJson<SupportTicketDetailRecord>(id ? `${apiBase}/${id}${toQueryString({ refresh: refreshNonce })}` : null);
   const ticket = ticketState.data;
@@ -114,12 +116,19 @@ export default function SupportTicketDetailPage({
       });
       const redirectPath = await resolvePostRedirectPath(response, ticket.actionPath || `${apiBase}/${id || ''}`);
       if (redirectPath !== location.pathname) {
-        navigate(redirectPath);
+        navigate(redirectPath, {
+          state: buildToastNavigationState({
+            variant: 'success',
+            message: 'Ticket updated successfully.'
+          })
+        });
       } else {
         setRefreshNonce(current => current + 1);
+        showToast({ variant: 'success', message: 'Ticket updated successfully.' });
       }
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save ticket.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -277,8 +286,6 @@ export default function SupportTicketDetailPage({
                     </div>
                   </label>
                 </div>
-
-                {saveState.error && <p className="error-text">{saveState.error}</p>}
 
                 {!isClosed && (canEditStatus || canEditCategory || canEditExternalIssue || canEditAffectsVersion || canEditResolvedVersion) && (
                   <div className="form-actions">

--- a/src/frontend/src/pages/TicketWorkbenchFormPage.tsx
+++ b/src/frontend/src/pages/TicketWorkbenchFormPage.tsx
@@ -9,6 +9,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { buildToastNavigationState, useToast } from '../components/common/ToastProvider';
 import DataState from '../components/common/DataState';
 import useJson from '../hooks/useJson';
 import useSubmissionGuard from '../hooks/useSubmissionGuard';
@@ -22,6 +23,7 @@ import { SUPPORT_TICKET_STATUSES } from '../types/tickets';
 
 export default function TicketWorkbenchFormPage({ sessionState }: SessionPageProps) {
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const { id } = useParams();
   const location = useLocation();
   const query = new URLSearchParams(location.search);
@@ -92,9 +94,15 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
         ['affectsVersionId', formState.affectsVersionId],
         ['resolvedVersionId', formState.resolvedVersionId]
       ]);
-      navigate(await resolvePostRedirectPath(response, '/tickets'));
+      navigate(await resolvePostRedirectPath(response, '/tickets'), {
+        state: buildToastNavigationState({
+          variant: 'success',
+          message: bootstrap.edit ? 'Ticket updated successfully.' : 'Ticket created successfully.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to save ticket.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to save ticket.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -109,9 +117,15 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
     try {
       setSaveState({ saving: true, error: '' });
       const response = await postForm(`/tickets/${id}/delete`, []);
-      navigate(await resolvePostRedirectPath(response, '/tickets'));
+      navigate(await resolvePostRedirectPath(response, '/tickets'), {
+        state: buildToastNavigationState({
+          variant: 'danger',
+          message: 'Ticket deleted.'
+        })
+      });
     } catch (error: unknown) {
       setSaveState({ saving: false, error: error instanceof Error ? error.message : 'Unable to delete ticket.' });
+      showToast({ variant: 'error', message: error instanceof Error ? error.message : 'Unable to delete ticket.' });
       return;
     } finally {
       submissionGuard.exit();
@@ -238,8 +252,6 @@ export default function TicketWorkbenchFormPage({ sessionState }: SessionPagePro
                 </ul>
               </section>
             )}
-
-            {saveState.error && <p className="error-text">{saveState.error}</p>}
 
             <div className="button-row">
               <button type="submit" className="primary-button" disabled={saveState.saving}>


### PR DESCRIPTION
Added a reusable global toast notification system for frontend request feedback. Success and error messages now display consistently at the bottom-right, persist across redirects, auto-dismiss, and delete actions use a destructive red variant for clearer UX.