### PR TITLE
[#118] Editor update

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -102,6 +102,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1985,6 +1986,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4355,6 +4357,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -4364,6 +4367,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4374,6 +4378,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4430,6 +4435,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -4691,6 +4697,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5105,6 +5112,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6288,6 +6296,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7537,6 +7546,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8349,7 +8359,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -8535,7 +8544,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -10741,6 +10749,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10783,6 +10792,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12325,6 +12335,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12661,6 +12672,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13106,6 +13118,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/src/components/editor/draggable-block-plugin.tsx
+++ b/src/frontend/src/components/editor/draggable-block-plugin.tsx
@@ -259,24 +259,24 @@ export function DraggableBlockPlugin({
         menuComponent={
           <div
             ref={menuRef}
-            className="draggable-block-menu absolute top-0 left-0 flex items-center opacity-0 will-change-transform"
+            className="draggable-block-menu absolute top-0 left-0 flex items-center gap-0.5 opacity-0 will-change-transform"
           >
             <Button
               variant="ghost"
               size="icon-xs"
               title="Click to add below (Alt/Ctrl: add above)"
-              className="cursor-pointer rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+              className="h-5 w-5 cursor-pointer rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
               onClick={openComponentPicker}
             >
-              <PlusIcon />
+              <PlusIcon className="size-3" />
             </Button>
             <Button
               variant="ghost"
               size="icon-xs"
-              className="cursor-grab rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground active:cursor-grabbing"
+              className="h-5 w-5 cursor-grab rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground active:cursor-grabbing"
               tabIndex={-1}
             >
-              <GripVerticalIcon className="opacity-60" />
+              <GripVerticalIcon className="size-3 opacity-60" />
             </Button>
           </div>
         }

--- a/src/frontend/src/components/editor/editor-theme.ts
+++ b/src/frontend/src/components/editor/editor-theme.ts
@@ -13,8 +13,8 @@ export const editorTheme: EditorThemeClasses = {
     h5: "scroll-m-20 text-lg font-semibold tracking-tight",
     h6: "scroll-m-20 text-base font-semibold tracking-tight",
   },
-  paragraph: "leading-7 [&:not(:first-child)]:mt-6",
-  quote: "mt-6 border-l-2 pl-6 italic",
+  paragraph: "my-1 leading-6",
+  quote: "my-2 border-l-2 pl-4 italic",
   link: "text-blue-600 hover:underline hover:cursor-pointer",
   list: {
     checklist: "relative",
@@ -26,7 +26,7 @@ export const editorTheme: EditorThemeClasses = {
     nested: {
       listitem: "list-none before:hidden after:hidden",
     },
-    ol: "m-0 p-0 list-decimal [&>li]:mt-2",
+    ol: "my-1 p-0 list-decimal [&>li]:mt-1",
     olDepth: [
       "list-outside !list-decimal",
       "list-outside !list-[upper-roman]",
@@ -34,7 +34,7 @@ export const editorTheme: EditorThemeClasses = {
       "list-outside !list-[upper-alpha]",
       "list-outside !list-[lower-alpha]",
     ],
-    ul: "m-0 p-0 list-outside [&>li]:mt-2",
+    ul: "my-1 p-0 list-outside [&>li]:mt-1",
     ulDepth: [
       "list-outside !list-disc",
       "list-outside !list-disc",

--- a/src/frontend/src/components/editor/floating-text-format-plugin.tsx
+++ b/src/frontend/src/components/editor/floating-text-format-plugin.tsx
@@ -9,7 +9,7 @@ import {
 
 import { createPortal } from "react-dom";
 
-import { $isCodeHighlightNode } from "@lexical/code";
+import { $createCodeNode, $isCodeHighlightNode } from "@lexical/code";
 import { $isLinkNode, TOGGLE_LINK_COMMAND } from "@lexical/link";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
@@ -77,6 +77,30 @@ function TextFormatFloatingToolbar({
       editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
     }
   }, [editor, isLink, setIsLinkEditMode]);
+
+  const formatCode = useCallback(() => {
+    editor.update(() => {
+      const selection = $getSelection();
+
+      if (!$isRangeSelection(selection)) {
+        return;
+      }
+
+      const textContent = selection.getTextContent();
+      if (textContent.includes("\n") || textContent.includes("\r")) {
+        const codeNode = $createCodeNode();
+        selection.insertNodes([codeNode]);
+
+        const codeSelection = $getSelection();
+        if ($isRangeSelection(codeSelection)) {
+          codeSelection.insertRawText(textContent);
+        }
+        return;
+      }
+
+      editor.dispatchCommand(FORMAT_TEXT_COMMAND, "code");
+    });
+  }, [editor]);
 
   function mouseMoveListener(e: MouseEvent) {
     if (
@@ -252,9 +276,7 @@ function TextFormatFloatingToolbar({
             <ToggleGroupItem
               value="code"
               aria-label="Toggle code"
-              onClick={() => {
-                editor.dispatchCommand(FORMAT_TEXT_COMMAND, "code");
-              }}
+              onClick={formatCode}
               size="sm"
             >
               <CodeIcon className="h-4 w-4" />

--- a/src/frontend/src/components/editor/themes/editor-theme.css
+++ b/src/frontend/src/components/editor/themes/editor-theme.css
@@ -1,8 +1,8 @@
 .EditorTheme__code {
-  background-color: transparent;
+  background-color: #f6f8fa;
   font-family: Menlo, Consolas, Monaco, monospace;
   display: block;
-  padding: 8px 8px 8px 52px;
+  padding: 12px;
   line-height: 1.53;
   font-size: 13px;
   margin: 0;
@@ -12,10 +12,11 @@
   border: 1px solid #ccc;
   position: relative;
   border-radius: 8px;
-  tab-size: 2;
+  tab-size: 4;
+  white-space: pre;
 }
 .EditorTheme__code:before {
-  content: attr(data-gutter);
+  content: none;
   position: absolute;
   background-color: transparent;
   border-right: 1px solid #ccc;

--- a/src/frontend/src/components/markdown/MarkdownContent.tsx
+++ b/src/frontend/src/components/markdown/MarkdownContent.tsx
@@ -6,15 +6,275 @@
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
 
-import type { ReactNode } from "react";
+import {
+  Fragment,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
+
+import { cn } from "@/lib/utils";
 
 interface MarkdownContentProps {
   children?: ReactNode;
+  className?: string;
 }
 
-export default function MarkdownContent({ children }: MarkdownContentProps) {
+type MarkdownBlock =
+  | {
+      content: string;
+      type: "markdown";
+    }
+  | {
+      headers: string[];
+      rows: string[][];
+      type: "table";
+    };
+
+function MarkdownCodeBlock({
+  children,
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"pre">) {
+  const preRef = useRef<HTMLPreElement | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const copyCode = async () => {
+    const text = preRef.current?.innerText || "";
+
+    if (!text) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <div className="group relative my-4">
+      <button
+        type="button"
+        className="absolute right-2 top-2 rounded border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground shadow-sm hover:text-foreground"
+        onClick={copyCode}
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+      <pre
+        ref={preRef}
+        className={cn(
+          "overflow-x-auto rounded-md border bg-muted p-4 pr-16 text-sm",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+const markdownComponents: Components = {
+  a: ({ className, ...props }: ComponentPropsWithoutRef<"a">) => (
+    <a
+      className={cn(
+        "font-medium text-[var(--color-header-bg)] underline underline-offset-2 hover:text-primary",
+        className,
+      )}
+      target="_blank"
+      rel="noreferrer"
+      {...props}
+    />
+  ),
+  blockquote: ({
+    className,
+    ...props
+  }: ComponentPropsWithoutRef<"blockquote">) => (
+    <blockquote
+      className={cn(
+        "my-4 border-l-4 border-border pl-4 italic text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  code: ({ className, ...props }: ComponentPropsWithoutRef<"code">) => (
+    <code
+      className={cn(
+        "whitespace-pre-wrap rounded bg-muted px-1 py-0.5 font-mono text-[0.9em]",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  h1: ({ className, ...props }: ComponentPropsWithoutRef<"h1">) => (
+    <h1
+      className={cn(
+        "mb-4 mt-6 text-3xl font-bold leading-tight text-foreground first:mt-0",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  h2: ({ className, ...props }: ComponentPropsWithoutRef<"h2">) => (
+    <h2
+      className={cn(
+        "mb-3 mt-5 text-2xl font-semibold leading-tight text-foreground first:mt-0",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  h3: ({ className, ...props }: ComponentPropsWithoutRef<"h3">) => (
+    <h3
+      className={cn(
+        "mb-3 mt-4 text-xl font-semibold leading-snug text-foreground first:mt-0",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  hr: ({ className, ...props }: ComponentPropsWithoutRef<"hr">) => (
+    <hr className={cn("my-6 border-border", className)} {...props} />
+  ),
+  li: ({ className, ...props }: ComponentPropsWithoutRef<"li">) => (
+    <li className={cn("my-1 pl-1", className)} {...props} />
+  ),
+  ol: ({ className, ...props }: ComponentPropsWithoutRef<"ol">) => (
+    <ol
+      className={cn("my-3 list-decimal space-y-1 pl-6", className)}
+      {...props}
+    />
+  ),
+  p: ({ className, ...props }: ComponentPropsWithoutRef<"p">) => (
+    <p
+      className={cn(
+        "my-3 whitespace-pre-wrap leading-7 first:mt-0 last:mb-0",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  pre: ({ className, ...props }: ComponentPropsWithoutRef<"pre">) => (
+    <MarkdownCodeBlock className={className} {...props} />
+  ),
+  table: ({ className, ...props }: ComponentPropsWithoutRef<"table">) => (
+    <div className="my-4 overflow-x-auto">
+      <table
+        className={cn("w-full border-collapse text-sm", className)}
+        {...props}
+      />
+    </div>
+  ),
+  td: ({ className, ...props }: ComponentPropsWithoutRef<"td">) => (
+    <td className={cn("border px-3 py-2 align-top", className)} {...props} />
+  ),
+  th: ({ className, ...props }: ComponentPropsWithoutRef<"th">) => (
+    <th
+      className={cn(
+        "border bg-muted px-3 py-2 text-left font-semibold",
+        className,
+      )}
+      {...props}
+    />
+  ),
+  ul: ({ className, ...props }: ComponentPropsWithoutRef<"ul">) => (
+    <ul className={cn("my-3 list-disc space-y-1 pl-6", className)} {...props} />
+  ),
+};
+
+const tableCellMarkdownComponents: Components = {
+  ...markdownComponents,
+  p: ({ children }) => <>{children}</>,
+};
+
+function isTableDivider(line: string): boolean {
+  return /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+(?:\s*:?-{3,}:?\s*)?\|?\s*$/.test(line);
+}
+
+function isTableRow(line: string): boolean {
+  return line.trim().startsWith("|") && line.trim().endsWith("|");
+}
+
+function splitTableRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function parseMarkdownBlocks(content: string): MarkdownBlock[] {
+  const lines = content.split(/\r?\n/);
+  const blocks: MarkdownBlock[] = [];
+  const markdownBuffer: string[] = [];
+
+  const flushMarkdown = () => {
+    const markdown = markdownBuffer.join("\n").trim();
+    if (markdown) {
+      blocks.push({ content: markdown, type: "markdown" });
+    }
+    markdownBuffer.length = 0;
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const divider = lines[index + 1];
+
+    if (isTableRow(line) && divider && isTableDivider(divider)) {
+      flushMarkdown();
+
+      const headers = splitTableRow(line);
+      const rows: string[][] = [];
+      index += 2;
+
+      while (index < lines.length && isTableRow(lines[index])) {
+        rows.push(splitTableRow(lines[index]));
+        index += 1;
+      }
+
+      blocks.push({ headers, rows, type: "table" });
+      index -= 1;
+    } else {
+      markdownBuffer.push(line);
+    }
+  }
+
+  flushMarkdown();
+  return blocks;
+}
+
+function renderMarkdown(content: string) {
+  return (
+    <ReactMarkdown
+      components={markdownComponents}
+      rehypePlugins={[rehypeHighlight]}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}
+
+function renderTableCell(content: string) {
+  return (
+    <ReactMarkdown
+      components={tableCellMarkdownComponents}
+      rehypePlugins={[rehypeHighlight]}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}
+
+export default function MarkdownContent({
+  children,
+  className,
+}: MarkdownContentProps) {
   let content = typeof children === "string" ? children : "";
 
   // Auto-correct common markdown formatting mistakes (e.g. spaces inside asterisks `** bold **`)
@@ -26,7 +286,52 @@ export default function MarkdownContent({ children }: MarkdownContentProps) {
     );
   }
 
+  const blocks = parseMarkdownBlocks(content);
+
   return (
-    <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{content}</ReactMarkdown>
+    <div className={cn("max-w-none text-sm text-foreground", className)}>
+      {blocks.map((block, blockIndex) => {
+        if (block.type === "markdown") {
+          return (
+            <Fragment key={`markdown-${blockIndex}`}>
+              {renderMarkdown(block.content)}
+            </Fragment>
+          );
+        }
+
+        return (
+          <div key={`table-${blockIndex}`} className="my-4 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr>
+                  {block.headers.map((header, headerIndex) => (
+                    <th
+                      key={`header-${headerIndex}`}
+                      className="border bg-muted px-3 py-2 text-left font-semibold"
+                    >
+                      {renderTableCell(header)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {block.rows.map((row, rowIndex) => (
+                  <tr key={`row-${rowIndex}`}>
+                    {block.headers.map((_, cellIndex) => (
+                      <td
+                        key={`cell-${rowIndex}-${cellIndex}`}
+                        className="border px-3 py-2 align-top"
+                      >
+                        {renderTableCell(row[cellIndex] || "")}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      })}
+    </div>
   );
 }


### PR DESCRIPTION
### Changes
- Added explicit markdown rendering styles for headings, lists, blockquotes, links, code, tables, and horizontal rules.
- Fixed Heading 1/2/3 display after saving messages/articles.
- Added support for rendering markdown pipe tables as actual tables.
- Preserved paragraph and inline-code line breaks in saved message/article views.
- Made multi-line code selections create a single code block instead of separate inline-code chips.
- Improved code block spacing/indentation in the editor.

## Before:
<img width="420" height="213" alt="Screenshot 2026-04-14 160758" src="https://github.com/user-attachments/assets/a7c003b3-fa17-4bcf-b285-e322ebb444da" />
<img width="1916" height="464" alt="Screenshot 2026-04-14 150222" src="https://github.com/user-attachments/assets/11539950-714b-4303-99df-2a59bd0935f4" />


## After:
<img width="1757" height="361" alt="image" src="https://github.com/user-attachments/assets/ce572b6a-0537-4759-9563-7ac7dbf88486" />

<img width="1058" height="271" alt="image" src="https://github.com/user-attachments/assets/d9099061-ac2a-4361-a3d8-36c8a64397be" />

<img width="581" height="232" alt="image" src="https://github.com/user-attachments/assets/1b783e30-541a-44ec-8420-32b86d85f8a9" />
