### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 all: clean format run
 
 frontend:
-	@cd src/frontend && npm install
+	@cd src/frontend && npm ci
 
 format:
 	@npm run frontend:fix -q


### PR DESCRIPTION
Update the frontend `Makefile` target to use `npm ci` instead of `npm install`.
This helps prevent unexpected `src/frontend/package-lock.json` churn across different npm versions.