### PR TITLE
[#118] Attachment Page: Use shadcn PageHeader

### DIFF
--- a/src/frontend/src/pages/AttachmentPage.tsx
+++ b/src/frontend/src/pages/AttachmentPage.tsx
@@ -14,6 +14,7 @@ import type { SessionPageProps } from "../types/app";
 import type { AttachmentDetail } from "../types/domain";
 import { Card, CardContent } from "../components/ui/card";
 import { Button } from "../components/ui/button";
+import PageHeader from "../components/layout/PageHeader";
 
 export default function AttachmentPage(props: SessionPageProps) {
   void props;
@@ -27,9 +28,7 @@ export default function AttachmentPage(props: SessionPageProps) {
     : attachment?.name || "Attachment";
   return (
     <section className="w-full mt-4">
-      <div className="pb-6 px-1 border-b mb-6">
-        <h2 className="text-3xl font-bold tracking-tight">{attachmentTitle}</h2>
-      </div>
+      <PageHeader title={attachmentTitle} titleClassName="text-3xl font-bold" />
 
       <DataState state={attachmentState} emptyMessage="Attachment not found.">
         {attachment && (


### PR DESCRIPTION
## Before
<img width="1920" height="1017" alt="Screenshot from 2026-04-18 21-07-40" src="https://github.com/user-attachments/assets/64003aae-18f3-4a63-87e0-9f771426be36" />

##  After
<img width="1920" height="1017" alt="Screenshot from 2026-04-18 21-19-20" src="https://github.com/user-attachments/assets/bcd17320-f655-4aa3-9324-94cca00e207b" />
