### PR TITLE
Fix lexical editor md format content parsing in admin pages

### DIFF
--- a/src/frontend/src/pages/CategoryDetailPage.tsx
+++ b/src/frontend/src/pages/CategoryDetailPage.tsx
@@ -18,6 +18,7 @@ import { Field, FieldLabel } from "../components/ui/field";
 import { Input } from "../components/ui/input";
 import { Badge } from "../components/ui/badge";
 import { Textarea } from "../components/ui/textarea";
+import MarkdownContent from "../components/markdown/MarkdownContent";
 
 export default function CategoryDetailPage(props: SessionPageProps) {
   void props;
@@ -56,12 +57,18 @@ export default function CategoryDetailPage(props: SessionPageProps) {
               </Field>
               <Field className="md:col-span-2">
                 <FieldLabel className="text-primary">Description</FieldLabel>
-                <Textarea
-                  value={category.description || "—"}
-                  readOnly
-                  rows={10}
-                  className="resize-none"
-                />
+                {category.description ? (
+                  <div className="w-full rounded-md border border-input bg-muted/50 px-3 py-2 text-sm [&_h1]:text-3xl [&_h1]:font-bold [&_h1]:tracking-tight [&_h1]:mb-6 [&_h1]:mt-2 [&_h2]:text-2xl [&_h2]:font-semibold [&_h2]:mb-4 [&_h2]:mt-8 [&_h2]:pb-2 [&_h2]:border-b [&_h2]:border-border/50 [&_h3]:text-xl [&_h3]:font-medium [&_h3]:mb-3 [&_h3]:mt-6 [&_ul]:my-4 [&_ul]:ms-6 [&_ul]:list-disc [&_ul_li]:pl-1 [&_ol]:my-4 [&_ol]:ms-6 [&_ol]:list-decimal [&_ol_li]:pl-1 [&_p]:my-4 [&_p]:leading-relaxed [&_p]:first:mt-0 [&_p]:last:mb-0 [&_a]:text-primary hover:[&_a]:underline [&_a]:underline-offset-4 [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded-md [&_code]:text-sm [&_blockquote]:border-l-4 [&_blockquote]:border-primary/50 [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-muted-foreground">
+                    <MarkdownContent>{category.description}</MarkdownContent>
+                  </div>
+                ) : (
+                  <Textarea
+                    value="—"
+                    readOnly
+                    rows={1}
+                    className="resize-none"
+                  />
+                )}
               </Field>
             </div>
 

--- a/src/frontend/src/pages/LevelDetailPage.tsx
+++ b/src/frontend/src/pages/LevelDetailPage.tsx
@@ -18,6 +18,7 @@ import { Button } from "../components/ui/button";
 import { Field, FieldLabel } from "../components/ui/field";
 import { Input } from "../components/ui/input";
 import { Textarea } from "../components/ui/textarea";
+import MarkdownContent from "../components/markdown/MarkdownContent";
 
 export default function LevelDetailPage(props: SessionPageProps) {
   void props;
@@ -85,12 +86,18 @@ export default function LevelDetailPage(props: SessionPageProps) {
                 <FieldLabel className="text-[var(--color-header-bg)]">
                   Description
                 </FieldLabel>
-                <Textarea
-                  value={level.description || "—"}
-                  readOnly
-                  rows={6}
-                  className="resize-none"
-                />
+                {level.description ? (
+                  <div className="w-full rounded-md border border-input bg-muted/50 px-3 py-2 text-sm [&_h1]:text-3xl [&_h1]:font-bold [&_h1]:tracking-tight [&_h1]:mb-6 [&_h1]:mt-2 [&_h2]:text-2xl [&_h2]:font-semibold [&_h2]:mb-4 [&_h2]:mt-8 [&_h2]:pb-2 [&_h2]:border-b [&_h2]:border-border/50 [&_h3]:text-xl [&_h3]:font-medium [&_h3]:mb-3 [&_h3]:mt-6 [&_ul]:my-4 [&_ul]:ms-6 [&_ul]:list-disc [&_ul_li]:pl-1 [&_ol]:my-4 [&_ol]:ms-6 [&_ol]:list-decimal [&_ol_li]:pl-1 [&_p]:my-4 [&_p]:leading-relaxed [&_p]:first:mt-0 [&_p]:last:mb-0 [&_a]:text-primary hover:[&_a]:underline [&_a]:underline-offset-4 [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded-md [&_code]:text-sm [&_blockquote]:border-l-4 [&_blockquote]:border-primary/50 [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-muted-foreground">
+                    <MarkdownContent>{level.description}</MarkdownContent>
+                  </div>
+                ) : (
+                  <Textarea
+                    value="—"
+                    readOnly
+                    rows={1}
+                    className="resize-none"
+                  />
+                )}
               </Field>
             </div>
 


### PR DESCRIPTION
## Before:
<img width="1915" height="847" alt="image" src="https://github.com/user-attachments/assets/a626c65d-3445-4004-9333-0bd134f95105" />
<img width="1916" height="982" alt="image" src="https://github.com/user-attachments/assets/d75a0c2b-e940-4850-b3ce-9ff1023f6cd2" />

## After:
<img width="1915" height="977" alt="image" src="https://github.com/user-attachments/assets/c2a4acc0-7cc4-4ea1-b420-635344158035" />
<img width="1913" height="912" alt="image" src="https://github.com/user-attachments/assets/828c2a46-6dee-4c34-9dae-8e9ae790541a" />
