### PR TITLE
[#113] Add ticket mentions cross-references

### DIFF
--- a/doc/entity-diagram.md
+++ b/doc/entity-diagram.md
@@ -89,6 +89,15 @@ erDiagram
         BIGINT article_id FK
     }
 
+    CROSS_REFERENCE {
+        BIGINT id PK
+        BIGINT message_id FK
+        BIGINT source_ticket_id FK
+        STRING target_type
+        BIGINT target_id
+        DATETIME created_at
+    }
+
     ARTICLE {
         BIGINT id PK
         STRING title
@@ -172,4 +181,6 @@ erDiagram
     LEVEL ||--o{ ENTITLEMENT_LEVEL : maps
     COMPANY_ENTITLEMENT ||--o{ TICKET : applies
     CATEGORY ||--o{ TICKET : categorizes
+    MESSAGE ||--o{ CROSS_REFERENCE : generates
+    TICKET ||--o{ CROSS_REFERENCE : sources
 ```

--- a/doc/manual/en/11-tickets.md
+++ b/doc/manual/en/11-tickets.md
@@ -85,6 +85,8 @@ The ticket detail page is where the full case comes together. It combines the cu
 
 This page is the main working area for understanding a case in context.
 
+Cross-references from other tickets that mention this ticket are shown in a dedicated Related section in the ticket header.
+
 ## External tracking
 
 Tickets can also include an external issue reference. This makes it easier to connect billetsys with development or defect tracking workflows outside the ticket system itself.

--- a/doc/manual/en/12-messages.md
+++ b/doc/manual/en/12-messages.md
@@ -36,6 +36,12 @@ Messages can include attachments when files are needed to explain or document an
 
 By keeping attachments inside the message flow, billetsys ensures that evidence and discussion stay connected.
 
+## Ticket mentions
+
+Messages support ticket cross-references using the `#` mention syntax. Typing `#` followed by a ticket identifier in the message editor opens a suggestion list. Selecting a ticket inserts a mention that links to the referenced ticket.
+
+Mentions create a cross-reference record. Referenced tickets appear in a dedicated Related section, and inline mentions in messages show a hover preview.
+
 ## Communication flow
 
 The message thread supports a continuous support conversation:

--- a/src/backend/main/java/ai/mnemosyne_systems/model/CrossReference.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/model/CrossReference.java
@@ -1,0 +1,50 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cross_references", uniqueConstraints = @UniqueConstraint(name = "uk_cross_ref_msg_type_target", columnNames = {
+        "message_id", "target_type", "target_id" }))
+public class CrossReference extends PanacheEntityBase {
+
+    @Id
+    @SequenceGenerator(name = "cross_reference_seq", sequenceName = "cross_reference_seq", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cross_reference_seq")
+    public Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "message_id", nullable = false)
+    public Message sourceMessage;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "source_ticket_id", nullable = false)
+    public Ticket sourceTicket;
+
+    @Column(name = "target_type", nullable = false)
+    public String targetType;
+
+    @Column(name = "target_id", nullable = false)
+    public Long targetId;
+
+    @Column(nullable = false)
+    public LocalDateTime createdAt;
+}

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
@@ -18,6 +18,7 @@ import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -60,6 +61,9 @@ public class SuperuserResource {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("MMMM d yyyy, h.mma",
             Locale.ENGLISH);
+
+    @Inject
+    CrossReferenceService crossReferenceService;
 
     @Inject
     TicketEmailService ticketEmailService;
@@ -218,6 +222,7 @@ public class SuperuserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        crossReferenceService.extractAndSaveReferences(message, null);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
         return createTicketRedirect(client, "/superuser/tickets/" + ticket.id);
@@ -309,6 +314,7 @@ public class SuperuserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        crossReferenceService.extractAndSaveReferences(message, null);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
         return Response.seeOther(URI.create("/superuser/tickets/" + id + "?replyAdded=1")).build();

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserTicketApiResource.java
@@ -8,6 +8,7 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.util.AuthHelper;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -31,6 +32,9 @@ import java.util.Set;
 @Path("/api/superuser/tickets")
 @Produces(MediaType.APPLICATION_JSON)
 public class SuperuserTicketApiResource {
+
+    @Inject
+    CrossReferenceService crossReferenceService;
 
     @Inject
     SuperuserResource superuserResource;
@@ -67,12 +71,16 @@ public class SuperuserTicketApiResource {
     @Path("/suggest")
     @Transactional
     public SupportTicketApiResource.TicketSuggestionResponse suggest(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
-            @QueryParam("view") @DefaultValue("assigned") String view, @QueryParam("q") String q) {
+            @QueryParam("view") @DefaultValue("assigned") String view, @QueryParam("q") String q,
+            @QueryParam("exclude") Long exclude) {
         User user = requireSuperuser(auth);
         SuperuserResource.SupportTicketData data = superuserResource.buildTicketDataForUser(user);
         List<Ticket> tickets = TicketSearchSupport.combineTickets(data.assignedTickets, data.openTickets,
                 data.closedTickets);
-        return new SupportTicketApiResource.TicketSuggestionResponse(TicketSearchSupport.suggestTickets(tickets, q, 8)
+        if (exclude != null) {
+            tickets = tickets.stream().filter(t -> t.id != null && !t.id.equals(exclude)).toList();
+        }
+        return new SupportTicketApiResource.TicketSuggestionResponse(TicketSearchSupport.suggestTickets(tickets, q, 6)
                 .stream().map(ticket -> new SupportTicketApiResource.TicketSuggestion(ticket.id, ticket.name,
                         ticket.displayTitle(), "/superuser/tickets/" + ticket.id))
                 .toList());
@@ -138,6 +146,8 @@ public class SuperuserTicketApiResource {
                 : User.find(
                         "select distinct u from Company c join c.users u where c = ?1 and lower(u.type) = ?2 order by u.email",
                         ticket.company, User.TYPE_SUPERUSER).list();
+        java.util.Map<Long, Ticket> ticketCache = crossReferenceService
+                .preloadReferencedTickets(messages.stream().map(m -> m.body).toList());
         return new UserTicketApiResource.RoleTicketDetailResponse(ticket.id, ticket.name, ticket.displayTitle(),
                 ticket.status == null || ticket.status.isBlank() ? "Open" : ticket.status,
                 data.assignedTickets == null ? 0 : data.assignedTickets.size(),
@@ -158,10 +168,23 @@ public class SuperuserTicketApiResource {
                 Category.<Category> list("order by name").stream().map(this::toCategoryOption).toList(),
                 supportUsers.stream().map(this::toUserReference).toList(), "Superusers",
                 secondaryUsers.stream().map(this::toUserReference).toList(),
-                messages.stream().map(this::toMessageEntry).toList(), superuserResource.isEntitlementExpired(ticket),
-                "/superuser/tickets/" + ticket.id, "/superuser/tickets/" + ticket.id + "/messages",
-                "/tickets/export/" + ticket.id, List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"), false,
-                false, false, true, true);
+                messages.stream().map(m -> toMessageEntry(m, ticketCache)).toList(),
+                superuserResource.isEntitlementExpired(ticket), "/superuser/tickets/" + ticket.id,
+                "/superuser/tickets/" + ticket.id + "/messages", "/tickets/export/" + ticket.id,
+                List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"), false, false, false, true, true);
+    }
+
+    @GET
+    @Path("/{id}/references")
+    @Transactional
+    public CrossReferenceService.CrossReferencesResponse references(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @PathParam("id") Long id) {
+        requireSuperuser(auth);
+        Ticket ticket = Ticket.findById(id);
+        if (ticket == null) {
+            throw new NotFoundException();
+        }
+        return crossReferenceService.getReferences(ticket, null, "/superuser/tickets/");
     }
 
     private SupportTicketApiResource.SupportTicketSummary toSummary(Ticket ticket,
@@ -197,9 +220,12 @@ public class SuperuserTicketApiResource {
                 user.timezone == null ? null : user.timezone.name, user.logoBase64, userPath(user));
     }
 
-    private SupportTicketApiResource.MessageEntry toMessageEntry(Message message) {
-        return new SupportTicketApiResource.MessageEntry(message.id, message.body,
-                message.date == null ? null : superuserResource.formatDate(message.date),
+    private SupportTicketApiResource.MessageEntry toMessageEntry(Message message,
+            java.util.Map<Long, Ticket> ticketCache) {
+        String transformedBody = crossReferenceService.transformBody(message.body, "/superuser/tickets/", ticketCache);
+        return new SupportTicketApiResource.MessageEntry(message.id, transformedBody,
+                message.date == null ? null : SupportTicketViewSupport.formatDate(message.date),
+                message.date == null ? null : message.date.toString(),
                 message.author == null ? null : toUserReference(message.author), message.attachments == null ? List.of()
                         : message.attachments.stream().map(this::toAttachmentEntry).toList());
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
@@ -18,6 +18,7 @@ import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
+import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -58,6 +59,9 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class SupportResource {
+    @Inject
+    CrossReferenceService crossReferenceService;
+
     @Inject
     TicketEmailService ticketEmailService;
 
@@ -279,6 +283,7 @@ public class SupportResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        crossReferenceService.extractAndSaveReferences(message, null);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         if (ticket.supportUsers.stream().noneMatch(existing -> existing.id != null && existing.id.equals(user.id))) {
             ticket.supportUsers.add(user);

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketApiResource.java
@@ -8,7 +8,9 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.util.AuthHelper;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.DefaultValue;
@@ -31,6 +33,9 @@ import java.util.Set;
 @Path("/api/support/tickets")
 @Produces(MediaType.APPLICATION_JSON)
 public class SupportTicketApiResource {
+
+    @Inject
+    CrossReferenceService crossReferenceService;
 
     @GET
     @Transactional
@@ -64,14 +69,18 @@ public class SupportTicketApiResource {
     @Path("/suggest")
     @Transactional
     public TicketSuggestionResponse suggest(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
-            @QueryParam("view") @DefaultValue("assigned") String view, @QueryParam("q") String q) {
+            @QueryParam("view") @DefaultValue("assigned") String view, @QueryParam("q") String q,
+            @QueryParam("exclude") Long exclude) {
         User user = requireSupport(auth);
         SupportTicketViewSupport.SupportTicketData data = SupportTicketViewSupport.buildTicketData(user);
         String normalizedView = normalizeView(view);
         List<Ticket> tickets = TicketSearchSupport.combineTickets(data.assignedTickets(), data.openTickets(),
                 data.closedTickets());
+        if (exclude != null) {
+            tickets = tickets.stream().filter(t -> t.id != null && !t.id.equals(exclude)).toList();
+        }
         return new TicketSuggestionResponse(
-                TicketSearchSupport.suggestTickets(tickets, q, 8).stream().map(ticket -> new TicketSuggestion(ticket.id,
+                TicketSearchSupport.suggestTickets(tickets, q, 6).stream().map(ticket -> new TicketSuggestion(ticket.id,
                         ticket.name, ticket.displayTitle(), "/support/tickets/" + ticket.id)).toList());
     }
 
@@ -129,7 +138,9 @@ public class SupportTicketApiResource {
                 ticket.company, User.TYPE_TAM).list();
         mergeTicketTams(ticket, tamUsers);
         List<Message> messages = SupportTicketViewSupport.loadMessages(ticket);
-        List<MessageEntry> messageEntries = messages.stream().map(this::toMessageEntry).toList();
+        java.util.Map<Long, Ticket> ticketCache = crossReferenceService
+                .preloadReferencedTickets(messages.stream().map(m -> m.body).toList());
+        List<MessageEntry> messageEntries = messages.stream().map(m -> toMessageEntry(m, ticketCache)).toList();
         return new SupportTicketDetailResponse(ticket.id, ticket.name, ticket.displayTitle(), displayStatus,
                 counts.assignedCount(), counts.openCount(), ticket.company == null ? null : ticket.company.id,
                 ticket.company == null ? null : ticket.company.name,
@@ -154,6 +165,19 @@ public class SupportTicketApiResource {
                 SupportTicketViewSupport.isEntitlementExpired(ticket), "/support/tickets/" + ticket.id,
                 "/support/tickets/" + ticket.id + "/messages", "/tickets/export/" + ticket.id,
                 List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"));
+    }
+
+    @GET
+    @Path("/{id}/references")
+    @Transactional
+    public CrossReferenceService.CrossReferencesResponse references(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @PathParam("id") Long id) {
+        requireSupport(auth);
+        Ticket ticket = Ticket.findById(id);
+        if (ticket == null) {
+            throw new NotFoundException();
+        }
+        return crossReferenceService.getReferences(ticket, null, "/support/tickets/");
     }
 
     private String normalizeView(String view) {
@@ -197,9 +221,11 @@ public class SupportTicketApiResource {
                 user.logoBase64, userPath(user));
     }
 
-    private MessageEntry toMessageEntry(Message message) {
-        return new MessageEntry(message.id, message.body,
+    private MessageEntry toMessageEntry(Message message, java.util.Map<Long, Ticket> ticketCache) {
+        String transformedBody = crossReferenceService.transformBody(message.body, "/support/tickets/", ticketCache);
+        return new MessageEntry(message.id, transformedBody,
                 message.date == null ? null : SupportTicketViewSupport.formatDate(message.date),
+                message.date == null ? null : message.date.toString(),
                 message.author == null ? null : toUserReference(message.author), message.attachments == null ? List.of()
                         : message.attachments.stream().map(this::toAttachmentEntry).toList());
     }
@@ -343,7 +369,7 @@ public class SupportTicketApiResource {
             String type, String countryName, String timezoneName, String logoBase64, String detailPath) {
     }
 
-    public record MessageEntry(Long id, String body, String dateLabel, UserReference author,
+    public record MessageEntry(Long id, String body, String dateLabel, String date, UserReference author,
             List<AttachmentEntry> attachments) {
     }
 

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -18,6 +18,7 @@ import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
+import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -54,6 +55,9 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class UserResource {
+    @Inject
+    CrossReferenceService crossReferenceService;
+
     @Inject
     TicketEmailService ticketEmailService;
 
@@ -371,6 +375,11 @@ public class UserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        SupportTicketData data = buildTicketDataForUser(user);
+        java.util.Set<Long> accessibleIds = TicketSearchSupport
+                .combineTickets(data.assignedTickets, data.openTickets, data.closedTickets).stream().map(t -> t.id)
+                .collect(java.util.stream.Collectors.toSet());
+        crossReferenceService.extractAndSaveReferences(message, accessibleIds);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
         return Response.seeOther(URI.create("/user/tickets/" + id + "?replyAdded=1")).build();

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserTicketApiResource.java
@@ -8,6 +8,7 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.util.AuthHelper;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -31,6 +32,9 @@ import java.util.Set;
 @Path("/api/user/tickets")
 @Produces(MediaType.APPLICATION_JSON)
 public class UserTicketApiResource {
+
+    @Inject
+    CrossReferenceService crossReferenceService;
 
     @Inject
     UserResource userResource;
@@ -67,12 +71,16 @@ public class UserTicketApiResource {
     @Path("/suggest")
     @Transactional
     public SupportTicketApiResource.TicketSuggestionResponse suggest(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
-            @QueryParam("view") @DefaultValue("assigned") String view, @QueryParam("q") String q) {
+            @QueryParam("view") @DefaultValue("assigned") String view, @QueryParam("q") String q,
+            @QueryParam("exclude") Long exclude) {
         User user = requireUser(auth);
         UserResource.SupportTicketData data = userResource.buildTicketDataForUser(user);
         List<Ticket> tickets = TicketSearchSupport.combineTickets(data.assignedTickets, data.openTickets,
                 data.closedTickets);
-        return new SupportTicketApiResource.TicketSuggestionResponse(TicketSearchSupport.suggestTickets(tickets, q, 8)
+        if (exclude != null) {
+            tickets = tickets.stream().filter(t -> t.id != null && !t.id.equals(exclude)).toList();
+        }
+        return new SupportTicketApiResource.TicketSuggestionResponse(TicketSearchSupport.suggestTickets(tickets, q, 6)
                 .stream().map(ticket -> new SupportTicketApiResource.TicketSuggestion(ticket.id, ticket.name,
                         ticket.displayTitle(), "/user/tickets/" + ticket.id))
                 .toList());
@@ -142,6 +150,8 @@ public class UserTicketApiResource {
                 .find("select u from Ticket t join t.tamUsers u where t = ?1 order by u.email", ticket).list();
         mergeMissingUsers(secondaryUsers, ticketTams);
         boolean tamView = User.TYPE_TAM.equalsIgnoreCase(user.type);
+        java.util.Map<Long, Ticket> ticketCache = crossReferenceService
+                .preloadReferencedTickets(messages.stream().map(m -> m.body).toList());
         return new RoleTicketDetailResponse(ticket.id, ticket.name, ticket.displayTitle(),
                 ticket.status == null || ticket.status.isBlank() ? "Open" : ticket.status,
                 data.assignedTickets == null ? 0 : data.assignedTickets.size(),
@@ -162,10 +172,27 @@ public class UserTicketApiResource {
                 Category.<Category> list("order by name").stream().map(this::toCategoryOption).toList(),
                 supportUsers.stream().map(this::toUserReference).toList(), "TAM",
                 secondaryUsers.stream().map(this::toUserReference).toList(),
-                messages.stream().map(this::toMessageEntry).toList(), userResource.isEntitlementExpired(ticket),
-                "/user/tickets/" + ticket.id, "/user/tickets/" + ticket.id + "/messages",
-                "/tickets/export/" + ticket.id, List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"), false,
-                false, false, true, tamView);
+                messages.stream().map(m -> toMessageEntry(m, ticketCache)).toList(),
+                userResource.isEntitlementExpired(ticket), "/user/tickets/" + ticket.id,
+                "/user/tickets/" + ticket.id + "/messages", "/tickets/export/" + ticket.id,
+                List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"), false, false, false, true, tamView);
+    }
+
+    @GET
+    @Path("/{id}/references")
+    @Transactional
+    public CrossReferenceService.CrossReferencesResponse references(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @PathParam("id") Long id) {
+        User user = requireUser(auth);
+        Ticket ticket = userResource.findTicketForUser(user, id);
+        if (ticket == null) {
+            throw new NotFoundException();
+        }
+        UserResource.SupportTicketData data = userResource.buildTicketDataForUser(user);
+        Set<Long> accessibleIds = TicketSearchSupport
+                .combineTickets(data.assignedTickets, data.openTickets, data.closedTickets).stream().map(t -> t.id)
+                .collect(java.util.stream.Collectors.toSet());
+        return crossReferenceService.getReferences(ticket, accessibleIds, "/user/tickets/");
     }
 
     private SupportTicketApiResource.SupportTicketSummary toSummary(Ticket ticket, UserResource.SupportTicketData data,
@@ -202,9 +229,12 @@ public class UserTicketApiResource {
                 user.timezone == null ? null : user.timezone.name, user.logoBase64, userPath(user));
     }
 
-    private SupportTicketApiResource.MessageEntry toMessageEntry(Message message) {
-        return new SupportTicketApiResource.MessageEntry(message.id, message.body,
-                message.date == null ? null : userResource.formatDate(message.date),
+    private SupportTicketApiResource.MessageEntry toMessageEntry(Message message,
+            java.util.Map<Long, Ticket> ticketCache) {
+        String transformedBody = crossReferenceService.transformBody(message.body, "/user/tickets/", ticketCache);
+        return new SupportTicketApiResource.MessageEntry(message.id, transformedBody,
+                message.date == null ? null : SupportTicketViewSupport.formatDate(message.date),
+                message.date == null ? null : message.date.toString(),
                 message.author == null ? null : toUserReference(message.author), message.attachments == null ? List.of()
                         : message.attachments.stream().map(this::toAttachmentEntry).toList());
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/service/CrossReferenceService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/CrossReferenceService.java
@@ -1,0 +1,188 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.service;
+
+import ai.mnemosyne_systems.model.CrossReference;
+import ai.mnemosyne_systems.model.Message;
+import ai.mnemosyne_systems.model.Ticket;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class CrossReferenceService {
+
+    public static final String TARGET_TYPE_TICKET = "ticket";
+
+    private record ReferenceTypeConfig(Pattern pattern, String targetType, String displayPrefix) {
+    }
+
+    private final List<ReferenceTypeConfig> configs = List
+            .of(new ReferenceTypeConfig(Pattern.compile("#\\[(\\d+)]"), TARGET_TYPE_TICKET, "#"));
+
+    public void extractAndSaveReferences(Message message, Set<Long> accessibleTicketIds) {
+        if (message == null || message.body == null || message.body.isBlank()) {
+            return;
+        }
+        Set<String> seen = new LinkedHashSet<>();
+        for (ReferenceTypeConfig config : configs) {
+            Matcher matcher = config.pattern.matcher(message.body);
+            while (matcher.find()) {
+                long targetId = Long.parseLong(matcher.group(1));
+                String key = config.targetType + ":" + targetId;
+                if (!seen.add(key)) {
+                    continue;
+                }
+                if (config.targetType.equals(TARGET_TYPE_TICKET)) {
+                    if (message.ticket != null && message.ticket.id != null && message.ticket.id.equals(targetId)) {
+                        continue;
+                    }
+                    if (accessibleTicketIds != null && !accessibleTicketIds.contains(targetId)) {
+                        continue;
+                    }
+                    Ticket target = Ticket.findById(targetId);
+                    if (target == null) {
+                        continue;
+                    }
+                }
+                CrossReference ref = new CrossReference();
+                ref.sourceMessage = message;
+                ref.sourceTicket = message.ticket;
+                ref.targetType = config.targetType;
+                ref.targetId = targetId;
+                ref.createdAt = LocalDateTime.now();
+                ref.persistAndFlush();
+            }
+        }
+    }
+
+    public Map<Long, Ticket> preloadReferencedTickets(List<String> bodies) {
+        Set<Long> allIds = new LinkedHashSet<>();
+        for (String body : bodies) {
+            if (body == null || body.isBlank()) {
+                continue;
+            }
+            for (ReferenceTypeConfig config : configs) {
+                if (!config.targetType.equals(TARGET_TYPE_TICKET)) {
+                    continue;
+                }
+                Matcher matcher = config.pattern.matcher(body);
+                while (matcher.find()) {
+                    allIds.add(Long.parseLong(matcher.group(1)));
+                }
+            }
+        }
+        if (allIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Ticket> tickets = Ticket.list("id in ?1", List.copyOf(allIds));
+        Map<Long, Ticket> map = new LinkedHashMap<>();
+        for (Ticket t : tickets) {
+            map.put(t.id, t);
+        }
+        return map;
+    }
+
+    public String transformBody(String body, String pathPrefix, Map<Long, Ticket> ticketCache) {
+        if (body == null || body.isBlank()) {
+            return body;
+        }
+        String result = body;
+        for (ReferenceTypeConfig config : configs) {
+            Matcher matcher = config.pattern.matcher(result);
+            StringBuilder sb = new StringBuilder();
+            while (matcher.find()) {
+                long targetId = Long.parseLong(matcher.group(1));
+                String replacement;
+                if (config.targetType.equals(TARGET_TYPE_TICKET)) {
+                    Ticket target = ticketCache.get(targetId);
+                    if (target != null) {
+                        String displayName = config.displayPrefix + target.name;
+                        replacement = "[" + displayName + "](" + pathPrefix + targetId + ")";
+                    } else {
+                        replacement = matcher.group(0);
+                    }
+                } else {
+                    replacement = matcher.group(0);
+                }
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            }
+            matcher.appendTail(sb);
+            result = sb.toString();
+        }
+        return result;
+    }
+
+    public CrossReferencesResponse getReferences(Ticket ticket, Set<Long> accessibleTicketIds, String pathPrefix) {
+        List<CrossReference> forward = CrossReference.list("sourceTicket = ?1 and targetType = ?2", ticket,
+                TARGET_TYPE_TICKET);
+        Set<Long> forwardIds = new LinkedHashSet<>();
+        for (CrossReference ref : forward) {
+            if (accessibleTicketIds != null && !accessibleTicketIds.contains(ref.targetId)) {
+                continue;
+            }
+            forwardIds.add(ref.targetId);
+        }
+        Map<Long, Ticket> forwardTickets = new LinkedHashMap<>();
+        if (!forwardIds.isEmpty()) {
+            List<Ticket> loaded = Ticket.list("id in ?1", List.copyOf(forwardIds));
+            for (Ticket t : loaded) {
+                forwardTickets.put(t.id, t);
+            }
+        }
+        List<CrossReferenceEntry> references = new ArrayList<>();
+        for (CrossReference ref : forward) {
+            Ticket target = forwardTickets.get(ref.targetId);
+            if (target != null) {
+                references.add(
+                        new CrossReferenceEntry(target.id, target.name, target.displayTitle(), pathPrefix + target.id,
+                                ref.createdAt, target.status, target.category != null ? target.category.name : null,
+                                target.company != null ? target.company.name : null,
+                                target.companyEntitlement != null && target.companyEntitlement.supportLevel != null
+                                        ? target.companyEntitlement.supportLevel.name
+                                        : null));
+            }
+        }
+
+        List<CrossReference> backward = CrossReference.list(
+                "select cr from CrossReference cr join fetch cr.sourceTicket where cr.targetType = ?1 and cr.targetId = ?2",
+                TARGET_TYPE_TICKET, ticket.id);
+        List<CrossReferenceEntry> referencedBy = new ArrayList<>();
+        for (CrossReference ref : backward) {
+            if (accessibleTicketIds != null && !accessibleTicketIds.contains(ref.sourceTicket.id)) {
+                continue;
+            }
+            referencedBy.add(new CrossReferenceEntry(ref.sourceTicket.id, ref.sourceTicket.name,
+                    ref.sourceTicket.displayTitle(), pathPrefix + ref.sourceTicket.id, ref.createdAt,
+                    ref.sourceTicket.status, ref.sourceTicket.category != null ? ref.sourceTicket.category.name : null,
+                    ref.sourceTicket.company != null ? ref.sourceTicket.company.name : null,
+                    ref.sourceTicket.companyEntitlement != null
+                            && ref.sourceTicket.companyEntitlement.supportLevel != null
+                                    ? ref.sourceTicket.companyEntitlement.supportLevel.name
+                                    : null));
+        }
+
+        return new CrossReferencesResponse(references, referencedBy);
+    }
+
+    public record CrossReferenceEntry(Long ticketId, String ticketName, String ticketTitle, String detailPath,
+            LocalDateTime createdAt, String status, String categoryName, String companyName, String levelName) {
+    }
+
+    public record CrossReferencesResponse(List<CrossReferenceEntry> references,
+            List<CrossReferenceEntry> referencedBy) {
+    }
+}

--- a/src/backend/main/java/ai/mnemosyne_systems/service/PdfService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/PdfService.java
@@ -19,6 +19,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +69,24 @@ public class PdfService {
             PdfPTable ticketTable = getPdfPTable(ticket);
             document.add(ticketTable);
             document.add(Chunk.NEWLINE);
+            // Related tickets
+            List<Ticket> relatedTickets = getRelatedTickets(ticket);
+            if (!relatedTickets.isEmpty()) {
+                Paragraph relatedSubTitle = new Paragraph("Related:", normalFont);
+                relatedSubTitle.setAlignment(Paragraph.ALIGN_LEFT);
+                relatedSubTitle.setSpacingAfter(20);
+                document.add(relatedSubTitle);
+                PdfPTable relatedTable = new PdfPTable(2);
+                relatedTable.setWidthPercentage(100);
+                relatedTable.addCell(createCell("Ticket", red, Color.WHITE));
+                relatedTable.addCell(createCell("Title", red, Color.WHITE));
+                for (Ticket related : relatedTickets) {
+                    relatedTable.addCell(new Phrase("#" + related.name, normalFont));
+                    relatedTable.addCell(new Phrase(related.displayTitle(), normalFont));
+                }
+                document.add(relatedTable);
+                document.add(Chunk.NEWLINE);
+            }
             // users subtitle
             Paragraph usersSubTitle = new Paragraph("Users:", normalFont);
             usersSubTitle.setAlignment(Paragraph.ALIGN_LEFT);
@@ -320,6 +339,30 @@ public class PdfService {
         ticketTable.addCell(createCell("Resolved", red, Color.WHITE));
         ticketTable.addCell(ticket.resolvedVersion == null ? "-" : ticket.resolvedVersion.name);
         return ticketTable;
+    }
+
+    private List<Ticket> getRelatedTickets(Ticket ticket) {
+        List<CrossReference> forward = CrossReference.list("sourceTicket = ?1 and targetType = 'ticket'", ticket);
+        List<CrossReference> backward = CrossReference.list(
+                "select cr from CrossReference cr join fetch cr.sourceTicket where cr.targetType = 'ticket' and cr.targetId = ?1",
+                ticket.id);
+        Map<Long, Ticket> unique = new LinkedHashMap<>();
+        List<Long> forwardIds = new ArrayList<>();
+        for (CrossReference ref : forward) {
+            forwardIds.add(ref.targetId);
+        }
+        if (!forwardIds.isEmpty()) {
+            List<Ticket> loaded = Ticket.list("id in ?1", forwardIds);
+            for (Ticket t : loaded) {
+                unique.put(t.id, t);
+            }
+        }
+        for (CrossReference ref : backward) {
+            unique.putIfAbsent(ref.sourceTicket.id, ref.sourceTicket);
+        }
+        List<Ticket> result = new ArrayList<>(unique.values());
+        result.sort(Comparator.comparing(t -> t.name));
+        return result;
     }
 
     private PdfPTable generateUsersTable(List<User> tams, List<User> supports) {

--- a/src/frontend/src/components/editor/LexicalEditor.tsx
+++ b/src/frontend/src/components/editor/LexicalEditor.tsx
@@ -58,6 +58,12 @@ import { EmojiNode } from "./emoji-node";
 import { LayoutContainerNode } from "./layout-container-node";
 import { LayoutItemNode } from "./layout-item-node";
 import { MentionNode } from "./mention-node";
+import {
+  TicketMentionNode,
+  $isTicketMentionNode,
+  $createTicketMentionNode,
+} from "./ticket-mention-node";
+import { TicketMentionsPlugin } from "./ticket-mentions-plugin";
 import { SpecialTextNode } from "./special-text-node";
 import { ActionsPlugin } from "./actions-plugin";
 import { ClearEditorActionPlugin } from "./clear-editor-plugin";
@@ -163,6 +169,8 @@ interface LexicalEditorProps {
   rows?: number;
   name?: string;
   required?: boolean;
+  ticketSuggestApiBase?: string;
+  excludeTicketId?: number | string;
 }
 
 const SUPERSCRIPT: TextMatchTransformer = {
@@ -203,12 +211,30 @@ const SUBSCRIPT: TextMatchTransformer = {
   type: "text-match",
 };
 
+const TICKET_MENTION: TextMatchTransformer = {
+  dependencies: [TicketMentionNode],
+  export: (node) => {
+    if (!$isTicketMentionNode(node)) return null;
+    return `#[${node.getTicketId()}]`;
+  },
+  importRegExp: /#\[(\d+)\]/,
+  regExp: /#\[(\d+)\]$/,
+  replace: (textNode, match) => {
+    const ticketId = Number(match[1]);
+    const node = $createTicketMentionNode(ticketId, String(ticketId), "");
+    textNode.replace(node);
+  },
+  trigger: "]",
+  type: "text-match",
+};
+
 const ALL_TRANSFORMERS = [
   TABLE,
   HR,
   IMAGE,
   EMOJI,
   TWEET,
+  TICKET_MENTION,
   CHECK_LIST,
   ...ELEMENT_TRANSFORMERS,
   ...MULTILINE_ELEMENT_TRANSFORMERS,
@@ -277,6 +303,8 @@ export default function LexicalEditor({
   inputRef,
   name,
   required,
+  ticketSuggestApiBase,
+  excludeTicketId,
 }: LexicalEditorProps) {
   const [floatingAnchorElem, setFloatingAnchorElem] =
     useState<HTMLDivElement | null>(null);
@@ -321,6 +349,7 @@ export default function LexicalEditor({
           OverflowNode,
           EmojiNode,
           MentionNode,
+          TicketMentionNode,
           AutocompleteNode,
           SpecialTextNode,
           CodeNode,
@@ -399,6 +428,12 @@ export default function LexicalEditor({
               <EmojiPickerPlugin />
               <AutoEmbedPlugin />
               <MentionsPlugin />
+              {ticketSuggestApiBase && (
+                <TicketMentionsPlugin
+                  apiBase={ticketSuggestApiBase}
+                  excludeTicketId={excludeTicketId}
+                />
+              )}
               <AutoCompletePlugin />
               <ContextMenuPlugin />
               <SpecialTextPlugin />

--- a/src/frontend/src/components/editor/ticket-mention-node.ts
+++ b/src/frontend/src/components/editor/ticket-mention-node.ts
@@ -1,0 +1,169 @@
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedTextNode,
+  type Spread,
+  TextNode,
+} from "lexical";
+
+export type SerializedTicketMentionNode = Spread<
+  {
+    ticketId: number;
+    ticketName: string;
+    ticketTitle: string;
+  },
+  SerializedTextNode
+>;
+
+function $convertTicketMentionElement(
+  domNode: HTMLElement,
+): DOMConversionOutput | null {
+  const ticketId = domNode.getAttribute("data-ticket-id");
+  const ticketName = domNode.getAttribute("data-ticket-name");
+  const textContent = domNode.textContent;
+
+  if (ticketId !== null && textContent !== null) {
+    const node = $createTicketMentionNode(
+      Number(ticketId),
+      ticketName || textContent,
+      "",
+    );
+    return { node };
+  }
+
+  return null;
+}
+
+const ticketMentionStyle =
+  "background-color: rgba(130, 80, 223, 0.15); border-radius: 3px; padding: 0 4px;";
+
+export class TicketMentionNode extends TextNode {
+  __ticketId: number;
+  __ticketName: string;
+  __ticketTitle: string;
+
+  static getType(): string {
+    return "ticket-mention";
+  }
+
+  static clone(node: TicketMentionNode): TicketMentionNode {
+    return new TicketMentionNode(
+      node.__ticketId,
+      node.__ticketName,
+      node.__ticketTitle,
+      node.__text,
+      node.__key,
+    );
+  }
+
+  static importJSON(
+    serializedNode: SerializedTicketMentionNode,
+  ): TicketMentionNode {
+    const node = $createTicketMentionNode(
+      serializedNode.ticketId,
+      serializedNode.ticketName,
+      serializedNode.ticketTitle,
+    );
+    node.setTextContent(serializedNode.text);
+    node.setFormat(serializedNode.format);
+    node.setDetail(serializedNode.detail);
+    node.setMode(serializedNode.mode);
+    node.setStyle(serializedNode.style);
+    return node;
+  }
+
+  constructor(
+    ticketId: number,
+    ticketName: string,
+    ticketTitle: string,
+    text?: string,
+    key?: NodeKey,
+  ) {
+    super(text ?? `#${ticketName}`, key);
+    this.__ticketId = ticketId;
+    this.__ticketName = ticketName;
+    this.__ticketTitle = ticketTitle;
+  }
+
+  exportJSON(): SerializedTicketMentionNode {
+    return {
+      ...super.exportJSON(),
+      ticketId: this.__ticketId,
+      ticketName: this.__ticketName,
+      ticketTitle: this.__ticketTitle,
+      type: "ticket-mention",
+      version: 1,
+    };
+  }
+
+  getTicketId(): number {
+    return this.__ticketId;
+  }
+
+  getTicketName(): string {
+    return this.__ticketName;
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = super.createDOM(config);
+    dom.style.cssText = ticketMentionStyle;
+    dom.className = "ticket-mention";
+    return dom;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.setAttribute("data-lexical-ticket-mention", "true");
+    element.setAttribute("data-ticket-id", String(this.__ticketId));
+    element.setAttribute("data-ticket-name", this.__ticketName);
+    element.textContent = this.__text;
+    return { element };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (domNode: HTMLElement) => {
+        if (!domNode.hasAttribute("data-lexical-ticket-mention")) {
+          return null;
+        }
+        return {
+          conversion: $convertTicketMentionElement,
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+
+  canInsertTextBefore(): boolean {
+    return false;
+  }
+
+  canInsertTextAfter(): boolean {
+    return false;
+  }
+}
+
+export function $createTicketMentionNode(
+  ticketId: number,
+  ticketName: string,
+  ticketTitle: string,
+): TicketMentionNode {
+  const node = new TicketMentionNode(ticketId, ticketName, ticketTitle);
+  node.setMode("segmented").toggleDirectionless();
+  return $applyNodeReplacement(node);
+}
+
+export function $isTicketMentionNode(
+  node: LexicalNode | null | undefined,
+): node is TicketMentionNode {
+  return node instanceof TicketMentionNode;
+}

--- a/src/frontend/src/components/editor/ticket-mentions-plugin.tsx
+++ b/src/frontend/src/components/editor/ticket-mentions-plugin.tsx
@@ -1,0 +1,279 @@
+import { type JSX, useCallback, useEffect, useMemo, useState } from "react";
+
+import { createPortal } from "react-dom";
+
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  MenuOption,
+  type MenuTextMatch,
+  useBasicTypeaheadTriggerMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { LexicalTypeaheadMenuPlugin } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { TextNode } from "lexical";
+
+import { TicketIcon } from "lucide-react";
+
+import { $createTicketMentionNode } from "@/components/editor/ticket-mention-node";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { toQueryString } from "@/utils/formatting";
+
+const TRIGGERS = ["#"].join("");
+const VALID_CHARS = "[^\\s#]";
+const LENGTH_LIMIT = 75;
+
+const TicketMentionsRegex = new RegExp(
+  "(^|\\s|\\()(" +
+    "[" +
+    TRIGGERS +
+    "]" +
+    "(" +
+    VALID_CHARS +
+    "{0," +
+    LENGTH_LIMIT +
+    "}" +
+    ")" +
+    ")$",
+);
+
+const SUGGESTION_LIST_LENGTH_LIMIT = 6;
+
+interface TicketSuggestion {
+  id: number;
+  name: string;
+  title: string;
+  detailPath: string;
+}
+
+interface TicketSuggestionResponse {
+  items?: TicketSuggestion[];
+}
+
+const ticketSuggestCache = new Map<string, TicketSuggestion[] | null>();
+
+function useTicketSuggestService(
+  queryString: string | null,
+  apiBase: string,
+  excludeTicketId?: number | string,
+): TicketSuggestion[] {
+  const [results, setResults] = useState<TicketSuggestion[]>([]);
+  const active = queryString != null && queryString.length >= 1;
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const cacheKey = `${apiBase}:${queryString}:${excludeTicketId || ""}`;
+    const cached = ticketSuggestCache.get(cacheKey);
+
+    if (cached === null) {
+      return;
+    }
+
+    ticketSuggestCache.set(cacheKey, null);
+
+    const queryParams: Record<string, string> = { q: queryString! };
+    if (excludeTicketId) {
+      queryParams.exclude = String(excludeTicketId);
+    }
+    const url = `${apiBase}/suggest${toQueryString(queryParams)}`;
+    fetch(url, { credentials: "same-origin", cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) {
+          return { items: [] } as TicketSuggestionResponse;
+        }
+        return (await response.json()) as TicketSuggestionResponse;
+      })
+      .then((data) => {
+        const items = data.items || [];
+        ticketSuggestCache.set(cacheKey, items);
+        setResults(items);
+      })
+      .catch(() => {
+        ticketSuggestCache.set(cacheKey, []);
+        setResults([]);
+      });
+  }, [active, queryString, apiBase, excludeTicketId]);
+
+  if (queryString == null) {
+    return [];
+  }
+
+  const cacheKey = `${apiBase}:${queryString}:${excludeTicketId || ""}`;
+  const cached = ticketSuggestCache.get(cacheKey);
+  return cached ?? results;
+}
+
+function checkForTicketMention(
+  text: string,
+  minMatchLength: number,
+): MenuTextMatch | null {
+  const match = TicketMentionsRegex.exec(text);
+  if (match !== null) {
+    const maybeLeadingWhitespace = match[1];
+    const matchingString = match[3];
+    if (matchingString.length >= minMatchLength) {
+      return {
+        leadOffset: match.index + maybeLeadingWhitespace.length,
+        matchingString,
+        replaceableString: match[2],
+      };
+    }
+  }
+  return null;
+}
+
+function getPossibleTicketQueryMatch(text: string): MenuTextMatch | null {
+  return checkForTicketMention(text, 1);
+}
+
+class TicketTypeaheadOption extends MenuOption {
+  id: number;
+  ticketName: string;
+  title: string;
+
+  constructor(id: number, ticketName: string, title: string) {
+    super(`${id}-${ticketName}`);
+    this.id = id;
+    this.ticketName = ticketName;
+    this.title = title;
+  }
+}
+interface TicketMentionsPluginProps {
+  apiBase: string;
+  excludeTicketId?: number | string;
+}
+
+export function TicketMentionsPlugin({
+  apiBase,
+  excludeTicketId,
+}: TicketMentionsPluginProps): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+
+  const [queryString, setQueryString] = useState<string | null>(null);
+
+  const results = useTicketSuggestService(
+    queryString,
+    apiBase,
+    excludeTicketId,
+  );
+
+  const checkForSlashTriggerMatch = useBasicTypeaheadTriggerMatch("/", {
+    minLength: 0,
+  });
+
+  const options = useMemo(
+    () =>
+      results
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(
+          (result) =>
+            new TicketTypeaheadOption(result.id, result.name, result.title),
+        )
+        .slice(0, SUGGESTION_LIST_LENGTH_LIMIT),
+    [results],
+  );
+
+  const onSelectOption = useCallback(
+    (
+      selectedOption: TicketTypeaheadOption,
+      nodeToReplace: TextNode | null,
+      closeMenu: () => void,
+    ) => {
+      editor.update(() => {
+        const ticketMentionNode = $createTicketMentionNode(
+          selectedOption.id,
+          selectedOption.ticketName,
+          selectedOption.title,
+        );
+        if (nodeToReplace) {
+          nodeToReplace.replace(ticketMentionNode);
+        }
+        ticketMentionNode.select();
+        closeMenu();
+      });
+    },
+    [editor],
+  );
+
+  const checkForMentionMatch = useCallback(
+    (text: string) => {
+      const slashMatch = checkForSlashTriggerMatch(text, editor);
+      if (slashMatch !== null) {
+        return null;
+      }
+      return getPossibleTicketQueryMatch(text);
+    },
+    [checkForSlashTriggerMatch, editor],
+  );
+
+  return (
+    <LexicalTypeaheadMenuPlugin
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      triggerFn={checkForMentionMatch}
+      options={options}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+      ) => {
+        return anchorElementRef.current && results.length
+          ? createPortal(
+              <div className="absolute z-10 min-w-64 rounded-md shadow-md">
+                <Command
+                  onKeyDown={(e) => {
+                    if (e.key === "ArrowUp") {
+                      e.preventDefault();
+                      setHighlightedIndex(
+                        selectedIndex !== null
+                          ? (selectedIndex - 1 + options.length) %
+                              options.length
+                          : options.length - 1,
+                      );
+                    } else if (e.key === "ArrowDown") {
+                      e.preventDefault();
+                      setHighlightedIndex(
+                        selectedIndex !== null
+                          ? (selectedIndex + 1) % options.length
+                          : 0,
+                      );
+                    }
+                  }}
+                >
+                  <CommandList>
+                    <CommandGroup>
+                      {options.map((option: TicketTypeaheadOption) => (
+                        <CommandItem
+                          key={option.key}
+                          value={`${option.id} ${option.ticketName} ${option.title}`}
+                          onSelect={() => {
+                            selectOptionAndCleanUp(option);
+                          }}
+                        >
+                          <span className="shrink-0 text-red-500">
+                            <TicketIcon className="size-4" />
+                          </span>
+                          <span className="font-medium shrink-0 whitespace-nowrap">
+                            {option.ticketName}
+                          </span>
+                          <span className="truncate text-muted-foreground text-sm">
+                            {option.title}
+                          </span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </div>,
+              anchorElementRef.current,
+            )
+          : null;
+      }}
+    />
+  );
+}

--- a/src/frontend/src/components/markdown/MarkdownContent.tsx
+++ b/src/frontend/src/components/markdown/MarkdownContent.tsx
@@ -8,6 +8,7 @@
 
 import {
   Fragment,
+  useMemo,
   useRef,
   useState,
   type ComponentPropsWithoutRef,
@@ -19,10 +20,13 @@ import rehypeHighlight from "rehype-highlight";
 
 import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
+import type { CrossReferenceEntry } from "@/types/domain/tickets";
+import { TicketHoverPreview } from "@/components/tickets/TicketHoverPreview";
 
 interface MarkdownContentProps {
   children?: ReactNode;
   className?: string;
+  crossReferences?: CrossReferenceEntry[];
 }
 
 type MarkdownBlock =
@@ -82,18 +86,60 @@ function MarkdownCodeBlock({
   );
 }
 
+function buildLinkComponent(
+  crossReferences?: CrossReferenceEntry[],
+): Components["a"] {
+  function MarkdownLink({
+    className,
+    href,
+    children,
+    ...props
+  }: ComponentPropsWithoutRef<"a">) {
+    if (crossReferences && href) {
+      const match = href.match(/\/(?:support|superuser|user)\/tickets\/(\d+)$/);
+      if (match) {
+        const ticketId = Number(match[1]);
+        const ref = crossReferences.find((r) => r.ticketId === ticketId);
+        if (ref) {
+          return (
+            <TicketHoverPreview
+              ticketName={ref.ticketName}
+              ticketTitle={ref.ticketTitle}
+              status={ref.status}
+              companyName={ref.companyName}
+              levelName={ref.levelName}
+              detailPath={ref.detailPath}
+              className={cn(
+                "text-red-500 underline underline-offset-2 hover:text-red-600",
+                className,
+              )}
+            >
+              {children}
+            </TicketHoverPreview>
+          );
+        }
+      }
+    }
+    return (
+      <a
+        className={cn(
+          "font-medium text-[var(--color-header-bg)] underline underline-offset-2 hover:text-primary",
+          className,
+        )}
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  }
+  return MarkdownLink;
+}
+
 const markdownComponents: Components = {
-  a: ({ className, ...props }: ComponentPropsWithoutRef<"a">) => (
-    <a
-      className={cn(
-        "font-medium text-[var(--color-header-bg)] underline underline-offset-2 hover:text-primary",
-        className,
-      )}
-      target="_blank"
-      rel="noreferrer"
-      {...props}
-    />
-  ),
+  a: buildLinkComponent(),
   blockquote: ({
     className,
     ...props
@@ -253,10 +299,10 @@ function parseMarkdownBlocks(content: string): MarkdownBlock[] {
   return blocks;
 }
 
-function renderMarkdown(content: string) {
+function renderMarkdown(content: string, components?: Components) {
   return (
     <ReactMarkdown
-      components={markdownComponents}
+      components={components ?? markdownComponents}
       rehypePlugins={[rehypeHighlight]}
     >
       {content}
@@ -278,6 +324,7 @@ function renderTableCell(content: string) {
 export default function MarkdownContent({
   children,
   className,
+  crossReferences,
 }: MarkdownContentProps) {
   let content = typeof children === "string" ? children : "";
 
@@ -292,13 +339,18 @@ export default function MarkdownContent({
 
   const blocks = parseMarkdownBlocks(content);
 
+  const components = useMemo(() => {
+    if (!crossReferences || crossReferences.length === 0) return undefined;
+    return { ...markdownComponents, a: buildLinkComponent(crossReferences) };
+  }, [crossReferences]);
+
   return (
     <div className={cn("max-w-none text-sm text-foreground", className)}>
       {blocks.map((block, blockIndex) => {
         if (block.type === "markdown") {
           return (
             <Fragment key={`markdown-${blockIndex}`}>
-              {renderMarkdown(block.content)}
+              {renderMarkdown(block.content, components)}
             </Fragment>
           );
         }

--- a/src/frontend/src/components/tickets/TicketHoverPreview.tsx
+++ b/src/frontend/src/components/tickets/TicketHoverPreview.tsx
@@ -1,0 +1,73 @@
+import type { MouseEvent, ReactNode } from "react";
+import { useState } from "react";
+
+interface TooltipState {
+  left: number;
+  top: number;
+}
+
+interface TicketHoverPreviewProps {
+  ticketName: string;
+  ticketTitle: string;
+  status?: string;
+  companyName?: string | null;
+  levelName?: string | null;
+  detailPath: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function TicketHoverPreview({
+  ticketName,
+  ticketTitle,
+  detailPath,
+  children,
+  className,
+}: TicketHoverPreviewProps) {
+  const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
+
+  const updateTooltip = (event: MouseEvent<HTMLAnchorElement>) => {
+    const pad = 12;
+    const width = 260;
+    const height = 120;
+    let left = event.clientX + pad;
+    let top = event.clientY + pad;
+    if (left + width > window.innerWidth - pad) {
+      left = event.clientX - width - pad;
+    }
+    if (top + height > window.innerHeight - pad) {
+      top = event.clientY - height - pad;
+    }
+    setTooltipState({ left, top });
+  };
+
+  return (
+    <>
+      <a
+        className={`text-primary hover:underline font-medium ${className || ""}`}
+        href={detailPath}
+        target="_blank"
+        rel="noreferrer"
+        onMouseEnter={updateTooltip}
+        onMouseMove={updateTooltip}
+        onMouseLeave={() => setTooltipState(null)}
+        onBlur={() => setTooltipState(null)}
+      >
+        {children}
+      </a>
+      {tooltipState && (
+        <div
+          className="fixed z-50 pointer-events-none"
+          style={{ left: tooltipState.left, top: tooltipState.top }}
+        >
+          <div className="bg-popover text-popover-foreground border shadow-md rounded-lg p-3 w-[260px] flex flex-col space-y-1.5 animate-in fade-in zoom-in-95 duration-100">
+            <div className="text-sm font-semibold truncate">#{ticketName}</div>
+            <div className="text-xs text-muted-foreground line-clamp-2">
+              {ticketTitle}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/pages/SupportTicketCreatePage.tsx
+++ b/src/frontend/src/pages/SupportTicketCreatePage.tsx
@@ -42,6 +42,7 @@ import {
 
 interface SupportTicketCreatePageProps extends SessionPageProps {
   apiBase?: string;
+  ticketSuggestApiBase?: string;
   backPath?: string;
   submitFallbackPath?: string;
   title?: string;
@@ -54,6 +55,7 @@ interface SupportTicketCreatePageProps extends SessionPageProps {
 export default function SupportTicketCreatePage({
   sessionState,
   apiBase = "/api/support/tickets/bootstrap",
+  ticketSuggestApiBase = "/api/support/tickets",
   submitFallbackPath = "/support/tickets",
   title = "",
   description = "",
@@ -380,6 +382,7 @@ export default function SupportTicketCreatePage({
                         inputRef={messageInputRef}
                         rows={10}
                         required
+                        ticketSuggestApiBase={ticketSuggestApiBase}
                       />
                     </Field>
                   </CardContent>
@@ -555,6 +558,7 @@ export default function SupportTicketCreatePage({
                       inputRef={messageInputRef}
                       rows={10}
                       required
+                      ticketSuggestApiBase={ticketSuggestApiBase}
                     />
                   </Field>
                 </>

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -31,6 +31,8 @@ import type { SessionPageProps } from "../types/app";
 import type {
   AttachmentDetail,
   AttachmentReference,
+  CrossReferenceEntry,
+  CrossReferencesResponse,
   MessageReference,
   NamedEntity,
   SupportTicketDetailRecord,
@@ -202,9 +204,11 @@ function AttachmentPreview({
 function TicketMessageCard({
   message,
   enableAttachmentPreviews,
+  crossReferences,
 }: {
   message: MessageReference;
   enableAttachmentPreviews: boolean;
+  crossReferences?: CrossReferenceEntry[];
 }) {
   const author = message.author;
   const authorLabel =
@@ -230,7 +234,9 @@ function TicketMessageCard({
 
       <div className="space-y-4 px-4 py-4">
         <div className="prose prose-sm max-w-none text-foreground dark:prose-invert [&>p:first-child]:mt-0 [&>p:last-child]:mb-0">
-          <MarkdownContent>{message.body || ""}</MarkdownContent>
+          <MarkdownContent crossReferences={crossReferences}>
+            {message.body || ""}
+          </MarkdownContent>
         </div>
       </div>
 
@@ -272,6 +278,9 @@ export default function SupportTicketDetailPage({
     id ? `${apiBase}/${id}${toQueryString({ refresh: refreshNonce })}` : null,
   );
   const ticket = ticketState.data;
+  const refsState = useJson<CrossReferencesResponse>(
+    id ? `${apiBase}/${id}/references` : null,
+  );
   const [formState, setFormState] = useState<SupportTicketDetailState | null>(
     null,
   );
@@ -730,6 +739,53 @@ export default function SupportTicketDetailPage({
                     </Select>
                   )}
                 </Field>
+                {(() => {
+                  const allRefs = [
+                    ...(refsState.data?.references ?? []),
+                    ...(refsState.data?.referencedBy ?? []),
+                  ];
+                  const unique = Array.from(
+                    new Map(allRefs.map((r) => [r.ticketId, r])).values(),
+                  ).sort((a, b) => a.ticketName.localeCompare(b.ticketName));
+                  return (
+                    <>
+                      {unique.length > 0 ? (
+                        <Field>
+                          <FieldLabel>Related</FieldLabel>
+                          <div className="border rounded-md overflow-hidden">
+                            <Table>
+                              <TableBody>
+                                {unique.map((ref) => (
+                                  <TableRow key={ref.ticketId}>
+                                    <TableCell className="text-sm border-r">
+                                      <a
+                                        href={ref.detailPath}
+                                        className="text-primary underline"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                      >
+                                        #{ref.ticketName}
+                                      </a>
+                                    </TableCell>
+                                    <TableCell className="text-sm text-muted-foreground truncate max-w-0 w-full">
+                                      {ref.ticketTitle}
+                                    </TableCell>
+                                  </TableRow>
+                                ))}
+                              </TableBody>
+                            </Table>
+                          </div>
+                        </Field>
+                      ) : (
+                        <Field>
+                          <FieldLabel>Related</FieldLabel>
+                          <div className="text-sm text-muted-foreground">-</div>
+                        </Field>
+                      )}
+                      <div className="hidden md:block" aria-hidden="true" />
+                    </>
+                  );
+                })()}
                 <Field>
                   <FieldLabel>Support</FieldLabel>
                   <UserReferenceInlineList users={ticket.supportUsers} />
@@ -771,17 +827,22 @@ export default function SupportTicketDetailPage({
                 </p>
               ) : (
                 <div className="space-y-4">
-                  {(ticket.messages || []).map((message: MessageReference) => (
-                    <TicketMessageCard
-                      key={message.id}
-                      message={message}
-                      enableAttachmentPreviews={enableAttachmentPreviews}
-                    />
-                  ))}
+                  {[...(ticket.messages || [])]
+                    .sort((a, b) => (b.date ?? "").localeCompare(a.date ?? ""))
+                    .map((message) => (
+                      <TicketMessageCard
+                        key={`msg-${message.id}`}
+                        message={message}
+                        enableAttachmentPreviews={enableAttachmentPreviews}
+                        crossReferences={[
+                          ...(refsState.data?.references ?? []),
+                          ...(refsState.data?.referencedBy ?? []),
+                        ]}
+                      />
+                    ))}
                 </div>
               )}
             </div>
-
             {!isClosed ? (
               <div className="space-y-4">
                 <h2 className="px-1 text-3xl font-bold tracking-tight">
@@ -795,6 +856,8 @@ export default function SupportTicketDetailPage({
                     name="body"
                     rows={6}
                     required
+                    ticketSuggestApiBase={apiBase}
+                    excludeTicketId={ticket.id}
                   />
 
                   <div className="space-y-3">

--- a/src/frontend/src/routes/TicketRoutes.tsx
+++ b/src/frontend/src/routes/TicketRoutes.tsx
@@ -161,6 +161,7 @@ export function getTicketRoutes(sessionState: SessionState): AppRoute[] {
         <SupportTicketCreatePage
           sessionState={sessionState}
           apiBase="/api/user/tickets/bootstrap"
+          ticketSuggestApiBase="/api/user/tickets"
           backPath={PATHS.userTickets}
           submitFallbackPath={PATHS.userTickets}
           title="New ticket"
@@ -247,6 +248,7 @@ export function getTicketRoutes(sessionState: SessionState): AppRoute[] {
         <SupportTicketCreatePage
           sessionState={sessionState}
           apiBase="/api/superuser/tickets/bootstrap"
+          ticketSuggestApiBase="/api/superuser/tickets"
           backPath={PATHS.superuserTickets}
           submitFallbackPath={PATHS.superuserTickets}
           navigateTo={PATHS.superuserTickets}

--- a/src/frontend/src/types/domain/tickets.ts
+++ b/src/frontend/src/types/domain/tickets.ts
@@ -96,3 +96,20 @@ export interface SupportTicketDetailRecord extends TicketReference {
   versions?: VersionInfo[];
   messages?: MessageReference[];
 }
+
+export interface CrossReferenceEntry {
+  ticketId: Id;
+  ticketName: string;
+  ticketTitle: string;
+  detailPath: string;
+  createdAt: string;
+  status: string;
+  categoryName: string | null;
+  companyName: string | null;
+  levelName: string | null;
+}
+
+export interface CrossReferencesResponse {
+  references: CrossReferenceEntry[];
+  referencedBy: CrossReferenceEntry[];
+}


### PR DESCRIPTION
- Adds `#` mention support in the message editor. Typing `#` opens a suggestion list of tickets filtered live as you type.
- Selecting one inserts a styled mention that links to the referenced ticket with a hover preview.
- `Related` tickets are shown in a dedicated section in the ticket header.
- Ticket PDF export includes a `Related` section as well.

<img width="529" height="273" alt="Screenshot from 2026-04-26 18-20-05" src="https://github.com/user-attachments/assets/ae12f84a-4526-472d-b0c0-d59ff994d45e" />

<img width="428" height="250" alt="image" src="https://github.com/user-attachments/assets/ae0e940b-37fb-4c79-aaaa-50c2497ab8d7" />

<img width="1786" height="290" alt="image" src="https://github.com/user-attachments/assets/0b3db878-e8ae-48d7-87bf-2b2b731381bd" />

<img width="890" height="188" alt="Screenshot from 2026-04-26 18-11-51" src="https://github.com/user-attachments/assets/d1213c95-1be2-458c-99de-828b440b7c54" />

Closes #113 