### PR TITLE
Fix locale-safe 12h clock formatting

### DIFF
--- a/src/frontend/src/utils/formatting.ts
+++ b/src/frontend/src/utils/formatting.ts
@@ -49,21 +49,11 @@ export function formatInstallationClock(
   value: Date,
   use24HourClock = false,
 ): string {
-  const formatter = new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat(undefined, {
     hour: use24HourClock ? "2-digit" : "numeric",
     minute: "2-digit",
     hour12: !use24HourClock,
-  });
-  const parts = formatter.formatToParts(value);
-  const hour = parts.find((part) => part.type === "hour")?.value || "";
-  const minute = parts.find((part) => part.type === "minute")?.value || "00";
-  if (use24HourClock) {
-    return `${hour}:${minute}`;
-  }
-  const dayPeriod = (
-    parts.find((part) => part.type === "dayPeriod")?.value || ""
-  ).toLowerCase();
-  return `${hour}:${minute}${dayPeriod}`;
+  }).format(value);
 }
 
 export function durationLabel(value: string | number): string {


### PR DESCRIPTION
Fixes a locale regression in the new 12h/24h clock formatter. 
The owner-level toggle still works, but we now let `Intl.DateTimeFormat` produce the final 12-hour string so locale-specific AM/PM ordering, spacing, and text are preserved.

