### PR TITLE
[#114] Add articles mentions

### DIFF
--- a/doc/manual/en/09-articles.md
+++ b/doc/manual/en/09-articles.md
@@ -68,6 +68,10 @@ This keeps article publishing aligned with operational responsibility.
 
 Articles support richer content than a plain note. They can include structured text and file attachments, which makes them useful for step-by-step guides, examples, and reference material.
 
+## Linked from tickets
+
+Ticket messages can reference articles using the `$` mention syntax in the message editor. In the rendered message, the mention is displayed as the article title. Each reference is recorded on the ticket and shown in a dedicated Articles section, sorted by title.
+
 ## Why it matters
 
 The articles feature turns day-to-day support experience into reusable organizational knowledge. Over time, that helps billetsys serve not only as a ticket system, but also as a knowledge platform for support teams and customers.

--- a/doc/manual/en/12-messages.md
+++ b/doc/manual/en/12-messages.md
@@ -51,6 +51,12 @@ Messages support ticket cross-references using the `#` mention syntax. Typing `#
 
 Mentions create a cross-reference record. Referenced tickets appear in a dedicated Related section, and inline mentions in messages show a hover preview.
 
+## Article mentions
+
+Messages support article references using the `$` mention syntax. Typing `$` followed by an article identifier in the message editor opens a suggestion list. Selecting an article inserts a mention that links to the referenced article.
+
+Article mentions create a reference record on the ticket side only, the referenced article itself is not modified. The inline mention in the rendered message displays the article title, while the dedicated Articles section on the ticket lists referenced articles sorted by title. Inline mentions in messages also show a hover preview.
+
 ## Communication flow
 
 The message thread supports a continuous support conversation:

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ArticleApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ArticleApiResource.java
@@ -15,15 +15,19 @@ import ai.mnemosyne_systems.util.AuthHelper;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @Path("/api/articles")
 @Produces(MediaType.APPLICATION_JSON)
@@ -45,6 +49,32 @@ public class ArticleApiResource {
     public ArticleBootstrapResponse bootstrap(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
         User user = requireUser(auth);
         return new ArticleBootstrapResponse(ArticleResource.canEdit(user), AuthHelper.isAdmin(user));
+    }
+
+    @GET
+    @Path("/suggest")
+    @Transactional
+    public ArticleSuggestionResponse suggest(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @QueryParam("q") @DefaultValue("") String q) {
+        requireUser(auth);
+        ArticleResource.ensureSampleArticle();
+        String needle = q == null ? "" : q.trim().toLowerCase(Locale.ROOT);
+        List<Article> all = Article.<Article> list("order by id desc");
+        List<ArticleSuggestion> matches = new ArrayList<>();
+        for (Article article : all) {
+            if (article.id == null) {
+                continue;
+            }
+            if (needle.isEmpty() || String.valueOf(article.id).contains(needle)
+                    || (article.title != null && article.title.toLowerCase(Locale.ROOT).contains(needle))) {
+                matches.add(new ArticleSuggestion(article.id, String.valueOf(article.id), article.title,
+                        "/articles/" + article.id));
+            }
+            if (matches.size() >= 6) {
+                break;
+            }
+        }
+        return new ArticleSuggestionResponse(matches);
     }
 
     @GET
@@ -83,6 +113,12 @@ public class ArticleApiResource {
     }
 
     public record ArticleSummary(Long id, String title, String tags) {
+    }
+
+    public record ArticleSuggestionResponse(List<ArticleSuggestion> items) {
+    }
+
+    public record ArticleSuggestion(Long id, String name, String title, String detailPath) {
     }
 
     public record ArticleDetailResponse(Long id, String title, String tags, String body, boolean canEdit,

--- a/src/backend/main/java/ai/mnemosyne_systems/service/CrossReferenceService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/CrossReferenceService.java
@@ -8,6 +8,7 @@
 
 package ai.mnemosyne_systems.service;
 
+import ai.mnemosyne_systems.model.Article;
 import ai.mnemosyne_systems.model.CrossReference;
 import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
@@ -26,12 +27,14 @@ import java.util.regex.Pattern;
 public class CrossReferenceService {
 
     public static final String TARGET_TYPE_TICKET = "ticket";
+    public static final String TARGET_TYPE_ARTICLE = "article";
 
-    private record ReferenceTypeConfig(Pattern pattern, String targetType, String displayPrefix) {
+    private record ReferenceTypeConfig(Pattern pattern, String targetType, String displayPrefix, String pathPrefix) {
     }
 
-    private final List<ReferenceTypeConfig> configs = List
-            .of(new ReferenceTypeConfig(Pattern.compile("#\\[(\\d+)]"), TARGET_TYPE_TICKET, "#"));
+    private final List<ReferenceTypeConfig> configs = List.of(
+            new ReferenceTypeConfig(Pattern.compile("#\\[(\\d+)]"), TARGET_TYPE_TICKET, "#", null),
+            new ReferenceTypeConfig(Pattern.compile("\\$\\[(\\d+)]"), TARGET_TYPE_ARTICLE, "$", "/articles/"));
 
     public void extractAndSaveReferences(Message message, Set<Long> accessibleTicketIds) {
         if (message == null || message.body == null || message.body.isBlank()) {
@@ -54,6 +57,11 @@ public class CrossReferenceService {
                         continue;
                     }
                     Ticket target = Ticket.findById(targetId);
+                    if (target == null) {
+                        continue;
+                    }
+                } else if (config.targetType.equals(TARGET_TYPE_ARTICLE)) {
+                    Article target = Article.findById(targetId);
                     if (target == null) {
                         continue;
                     }
@@ -112,6 +120,15 @@ public class CrossReferenceService {
                     if (target != null) {
                         String displayName = config.displayPrefix + target.name;
                         replacement = "[" + displayName + "](" + pathPrefix + targetId + ")";
+                    } else {
+                        replacement = matcher.group(0);
+                    }
+                } else if (config.targetType.equals(TARGET_TYPE_ARTICLE)) {
+                    Article article = Article.findById(targetId);
+                    if (article != null) {
+                        String displayName = article.title != null && !article.title.isBlank() ? article.title
+                                : config.displayPrefix + article.id;
+                        replacement = "[" + displayName + "](" + config.pathPrefix + article.id + ")";
                     } else {
                         replacement = matcher.group(0);
                     }
@@ -175,14 +192,97 @@ public class CrossReferenceService {
                                     : null));
         }
 
-        return new CrossReferencesResponse(references, referencedBy);
+        List<CrossReference> articleRefs = CrossReference.list("sourceTicket = ?1 and targetType = ?2", ticket,
+                TARGET_TYPE_ARTICLE);
+        List<ArticleReferenceEntry> articles = new ArrayList<>();
+        if (!articleRefs.isEmpty()) {
+            Set<Long> articleIds = new LinkedHashSet<>();
+            for (CrossReference ref : articleRefs) {
+                articleIds.add(ref.targetId);
+            }
+            List<Article> loadedArticles = Article.list("id in ?1", List.copyOf(articleIds));
+            Map<Long, Article> articleMap = new LinkedHashMap<>();
+            for (Article a : loadedArticles) {
+                articleMap.put(a.id, a);
+            }
+            for (CrossReference ref : articleRefs) {
+                Article a = articleMap.get(ref.targetId);
+                if (a != null) {
+                    articles.add(new ArticleReferenceEntry(a.id, String.valueOf(a.id), a.title, buildExcerpt(a.body),
+                            "/articles/" + a.id));
+                }
+            }
+            articles.sort((l, r) -> {
+                String lt = l.articleTitle() == null ? "" : l.articleTitle();
+                String rt = r.articleTitle() == null ? "" : r.articleTitle();
+                return lt.compareToIgnoreCase(rt);
+            });
+        }
+
+        return new CrossReferencesResponse(references, referencedBy, articles);
     }
 
     public record CrossReferenceEntry(Long ticketId, String ticketName, String ticketTitle, String detailPath,
             LocalDateTime createdAt, String status, String categoryName, String companyName, String levelName) {
     }
 
-    public record CrossReferencesResponse(List<CrossReferenceEntry> references,
-            List<CrossReferenceEntry> referencedBy) {
+    public static final int EXCERPT_MAX_LENGTH = 180;
+
+    public static String buildExcerpt(String body) {
+        if (body == null) {
+            return "";
+        }
+        String stripped = body.replaceAll("(?s)```.*?```", " ").replaceAll("`([^`]+)`", "$1")
+                .replaceAll("!\\[[^\\]]*]\\([^)]*\\)", " ").replaceAll("\\[([^\\]]+)]\\([^)]*\\)", "$1")
+                .replaceAll("[#>*_~|\\-]+", " ").replaceAll("\\s+", " ").trim();
+        if (stripped.length() <= EXCERPT_MAX_LENGTH) {
+            return stripped;
+        }
+        return stripped.substring(0, EXCERPT_MAX_LENGTH).trim() + "...";
+    }
+
+    public String transformBodyForPdf(String body, Map<Long, Ticket> ticketCache) {
+        if (body == null || body.isBlank()) {
+            return body;
+        }
+        String result = body;
+        for (ReferenceTypeConfig config : configs) {
+            Matcher matcher = config.pattern.matcher(result);
+            StringBuilder sb = new StringBuilder();
+            while (matcher.find()) {
+                long targetId = Long.parseLong(matcher.group(1));
+                String replacement;
+                if (config.targetType.equals(TARGET_TYPE_TICKET)) {
+                    Ticket target = ticketCache.get(targetId);
+                    if (target != null) {
+                        replacement = config.displayPrefix + target.name;
+                    } else {
+                        replacement = matcher.group(0);
+                    }
+                } else if (config.targetType.equals(TARGET_TYPE_ARTICLE)) {
+                    Article article = Article.findById(targetId);
+                    if (article != null) {
+                        replacement = article.title != null && !article.title.isBlank() ? article.title
+                                : config.displayPrefix + article.id;
+                    } else {
+                        replacement = matcher.group(0);
+                    }
+                } else {
+                    replacement = matcher.group(0);
+                }
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            }
+            matcher.appendTail(sb);
+            result = sb.toString();
+        }
+        return result;
+    }
+
+    public record ArticleReferenceEntry(Long articleId, String articleName, String articleTitle, String articleExcerpt,
+            String detailPath) {
+    }
+
+    public record CrossReferencesResponse(List<CrossReferenceEntry> references, List<CrossReferenceEntry> referencedBy,
+            List<ArticleReferenceEntry> articles) {
     }
 }

--- a/src/backend/main/java/ai/mnemosyne_systems/service/PdfService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/PdfService.java
@@ -25,6 +25,10 @@ import java.util.Map;
 
 @ApplicationScoped
 public class PdfService {
+
+    @jakarta.inject.Inject
+    CrossReferenceService crossReferenceService;
+
     private final Color red = new Color(176, 0, 32);
     private final Color lightRedFontColor = new Color(178, 15, 30);
     private final Color lightRed = new Color(244, 235, 236);
@@ -85,6 +89,22 @@ public class PdfService {
                     relatedTable.addCell(new Phrase(related.displayTitle(), normalFont));
                 }
                 document.add(relatedTable);
+                document.add(Chunk.NEWLINE);
+            }
+            // Related articles
+            List<Article> relatedArticles = getRelatedArticles(ticket);
+            if (!relatedArticles.isEmpty()) {
+                Paragraph articlesSubTitle = new Paragraph("Articles:", normalFont);
+                articlesSubTitle.setAlignment(Paragraph.ALIGN_LEFT);
+                articlesSubTitle.setSpacingAfter(20);
+                document.add(articlesSubTitle);
+                PdfPTable articlesTable = new PdfPTable(1);
+                articlesTable.setWidthPercentage(100);
+                articlesTable.addCell(createCell("Title", red, Color.WHITE));
+                for (Article article : relatedArticles) {
+                    articlesTable.addCell(new Phrase(article.title == null ? "" : article.title, normalFont));
+                }
+                document.add(articlesTable);
                 document.add(Chunk.NEWLINE);
             }
             // users subtitle
@@ -365,6 +385,25 @@ public class PdfService {
         return result;
     }
 
+    private List<Article> getRelatedArticles(Ticket ticket) {
+        List<CrossReference> refs = CrossReference.list("sourceTicket = ?1 and targetType = 'article'", ticket);
+        if (refs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Long> ids = new ArrayList<>();
+        for (CrossReference ref : refs) {
+            ids.add(ref.targetId);
+        }
+        List<Article> loaded = Article.list("id in ?1", ids);
+        Map<Long, Article> unique = new LinkedHashMap<>();
+        for (Article a : loaded) {
+            unique.put(a.id, a);
+        }
+        List<Article> result = new ArrayList<>(unique.values());
+        result.sort(Comparator.comparing(a -> a.title == null ? "" : a.title, String.CASE_INSENSITIVE_ORDER));
+        return result;
+    }
+
     private PdfPTable generateUsersTable(List<User> tams, List<User> supports) {
         List<User> safeTams = tams == null ? Collections.emptyList() : tams;
         List<User> safeSupports = supports == null ? Collections.emptyList() : supports;
@@ -399,6 +438,10 @@ public class PdfService {
             messageTable.addCell(emptyCell);
             return messageTable;
         }
+
+        Map<Long, Ticket> ticketCache = crossReferenceService
+                .preloadReferencedTickets(safeMessages.stream().map(m -> m.body).toList());
+
         for (Message message : safeMessages) {
             messageTable.addCell(createCell(message.date.format(formatter), red, Color.WHITE));
             messageTable.addCell(createCell(message.author == null ? "-" : message.author.email, red, Color.WHITE));
@@ -414,7 +457,8 @@ public class PdfService {
             }
             PdfPCell mergedCell = new PdfPCell();
             mergedCell.setColspan(2);
-            mergedCell.addElement(new Paragraph(message.body == null ? "" : message.body));
+            String transformedBody = crossReferenceService.transformBodyForPdf(message.body, ticketCache);
+            mergedCell.addElement(new Paragraph(transformedBody == null ? "" : transformedBody));
             mergedCell.addElement(new Paragraph(" "));
             mergedCell.addElement(attachmentTable);
             messageTable.addCell(mergedCell);

--- a/src/frontend/src/components/articles/ArticleHoverPreview.tsx
+++ b/src/frontend/src/components/articles/ArticleHoverPreview.tsx
@@ -1,0 +1,69 @@
+import type { MouseEvent, ReactNode } from "react";
+import { useState } from "react";
+
+interface TooltipState {
+  left: number;
+  top: number;
+}
+
+interface ArticleHoverPreviewProps {
+  articleTitle: string;
+  articleExcerpt: string;
+  detailPath: string;
+  children: ReactNode;
+  className?: string;
+}
+export function ArticleHoverPreview({
+  articleTitle,
+  articleExcerpt,
+  detailPath,
+  children,
+  className,
+}: ArticleHoverPreviewProps) {
+  const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
+
+  const updateTooltip = (event: MouseEvent<HTMLAnchorElement>) => {
+    const pad = 12;
+    const width = 260;
+    const height = 120;
+    let left = event.clientX + pad;
+    let top = event.clientY + pad;
+    if (left + width > window.innerWidth - pad) {
+      left = event.clientX - width - pad;
+    }
+    if (top + height > window.innerHeight - pad) {
+      top = event.clientY - height - pad;
+    }
+    setTooltipState({ left, top });
+  };
+
+  return (
+    <>
+      <a
+        className={`text-primary hover:underline font-medium ${className || ""}`}
+        href={detailPath}
+        target="_blank"
+        rel="noreferrer"
+        onMouseEnter={updateTooltip}
+        onMouseMove={updateTooltip}
+        onMouseLeave={() => setTooltipState(null)}
+        onBlur={() => setTooltipState(null)}
+      >
+        {children}
+      </a>
+      {tooltipState && (
+        <div
+          className="fixed z-50 pointer-events-none"
+          style={{ left: tooltipState.left, top: tooltipState.top }}
+        >
+          <div className="bg-popover text-popover-foreground border shadow-md rounded-lg p-3 w-[260px] flex flex-col space-y-1.5 animate-in fade-in zoom-in-95 duration-100">
+            <div className="text-sm font-semibold truncate">{articleTitle}</div>
+            <div className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap">
+              {articleExcerpt}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/components/editor/LexicalEditor.tsx
+++ b/src/frontend/src/components/editor/LexicalEditor.tsx
@@ -64,6 +64,12 @@ import {
   $createTicketMentionNode,
 } from "./ticket-mention-node";
 import { TicketMentionsPlugin } from "./ticket-mentions-plugin";
+import {
+  ArticleMentionNode,
+  $isArticleMentionNode,
+  $createArticleMentionNode,
+} from "./article-mention-node";
+import { ArticleMentionsPlugin } from "./article-mentions-plugin";
 import { SpecialTextNode } from "./special-text-node";
 import { ActionsPlugin } from "./actions-plugin";
 import { ClearEditorActionPlugin } from "./clear-editor-plugin";
@@ -228,6 +234,23 @@ const TICKET_MENTION: TextMatchTransformer = {
   type: "text-match",
 };
 
+const ARTICLE_MENTION: TextMatchTransformer = {
+  dependencies: [ArticleMentionNode],
+  export: (node) => {
+    if (!$isArticleMentionNode(node)) return null;
+    return `$[${node.getArticleId()}]`;
+  },
+  importRegExp: /\$\[(\d+)\]/,
+  regExp: /\$\[(\d+)\]$/,
+  replace: (textNode, match) => {
+    const articleId = Number(match[1]);
+    const node = $createArticleMentionNode(articleId, String(articleId), "");
+    textNode.replace(node);
+  },
+  trigger: "]",
+  type: "text-match",
+};
+
 const ALL_TRANSFORMERS = [
   TABLE,
   HR,
@@ -235,6 +258,7 @@ const ALL_TRANSFORMERS = [
   EMOJI,
   TWEET,
   TICKET_MENTION,
+  ARTICLE_MENTION,
   CHECK_LIST,
   ...ELEMENT_TRANSFORMERS,
   ...MULTILINE_ELEMENT_TRANSFORMERS,
@@ -350,6 +374,7 @@ export default function LexicalEditor({
           EmojiNode,
           MentionNode,
           TicketMentionNode,
+          ArticleMentionNode,
           AutocompleteNode,
           SpecialTextNode,
           CodeNode,
@@ -434,6 +459,7 @@ export default function LexicalEditor({
                   excludeTicketId={excludeTicketId}
                 />
               )}
+              <ArticleMentionsPlugin />
               <AutoCompletePlugin />
               <ContextMenuPlugin />
               <SpecialTextPlugin />

--- a/src/frontend/src/components/editor/article-mention-node.ts
+++ b/src/frontend/src/components/editor/article-mention-node.ts
@@ -1,0 +1,175 @@
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedTextNode,
+  type Spread,
+  TextNode,
+} from "lexical";
+
+export type SerializedArticleMentionNode = Spread<
+  {
+    articleId: number;
+    articleName: string;
+    articleTitle: string;
+  },
+  SerializedTextNode
+>;
+
+function $convertArticleMentionElement(
+  domNode: HTMLElement,
+): DOMConversionOutput | null {
+  const articleId = domNode.getAttribute("data-article-id");
+  const articleName = domNode.getAttribute("data-article-name");
+  const textContent = domNode.textContent;
+
+  if (articleId !== null && textContent !== null) {
+    const node = $createArticleMentionNode(
+      Number(articleId),
+      articleName || textContent,
+      "",
+    );
+    return { node };
+  }
+
+  return null;
+}
+
+const articleMentionStyle =
+  "background-color: rgba(130, 80, 223, 0.15); border-radius: 3px; padding: 0 4px;";
+
+export class ArticleMentionNode extends TextNode {
+  __articleId: number;
+  __articleName: string;
+  __articleTitle: string;
+
+  static getType(): string {
+    return "article-mention";
+  }
+
+  static clone(node: ArticleMentionNode): ArticleMentionNode {
+    return new ArticleMentionNode(
+      node.__articleId,
+      node.__articleName,
+      node.__articleTitle,
+      node.__text,
+      node.__key,
+    );
+  }
+
+  static importJSON(
+    serializedNode: SerializedArticleMentionNode,
+  ): ArticleMentionNode {
+    const node = $createArticleMentionNode(
+      serializedNode.articleId,
+      serializedNode.articleName,
+      serializedNode.articleTitle,
+    );
+    node.setTextContent(serializedNode.text);
+    node.setFormat(serializedNode.format);
+    node.setDetail(serializedNode.detail);
+    node.setMode(serializedNode.mode);
+    node.setStyle(serializedNode.style);
+    return node;
+  }
+
+  constructor(
+    articleId: number,
+    articleName: string,
+    articleTitle: string,
+    text?: string,
+    key?: NodeKey,
+  ) {
+    super(
+      text ??
+        (articleTitle && articleTitle.length > 0
+          ? articleTitle
+          : `$${articleName}`),
+      key,
+    );
+    this.__articleId = articleId;
+    this.__articleName = articleName;
+    this.__articleTitle = articleTitle;
+  }
+
+  exportJSON(): SerializedArticleMentionNode {
+    return {
+      ...super.exportJSON(),
+      articleId: this.__articleId,
+      articleName: this.__articleName,
+      articleTitle: this.__articleTitle,
+      type: "article-mention",
+      version: 1,
+    };
+  }
+
+  getArticleId(): number {
+    return this.__articleId;
+  }
+
+  getArticleName(): string {
+    return this.__articleName;
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = super.createDOM(config);
+    dom.style.cssText = articleMentionStyle;
+    dom.className = "article-mention";
+    return dom;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.setAttribute("data-lexical-article-mention", "true");
+    element.setAttribute("data-article-id", String(this.__articleId));
+    element.setAttribute("data-article-name", this.__articleName);
+    element.textContent = this.__text;
+    return { element };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (domNode: HTMLElement) => {
+        if (!domNode.hasAttribute("data-lexical-article-mention")) {
+          return null;
+        }
+        return {
+          conversion: $convertArticleMentionElement,
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+
+  canInsertTextBefore(): boolean {
+    return false;
+  }
+
+  canInsertTextAfter(): boolean {
+    return false;
+  }
+}
+
+export function $createArticleMentionNode(
+  articleId: number,
+  articleName: string,
+  articleTitle: string,
+): ArticleMentionNode {
+  const node = new ArticleMentionNode(articleId, articleName, articleTitle);
+  node.setMode("segmented").toggleDirectionless();
+  return $applyNodeReplacement(node);
+}
+
+export function $isArticleMentionNode(
+  node: LexicalNode | null | undefined,
+): node is ArticleMentionNode {
+  return node instanceof ArticleMentionNode;
+}

--- a/src/frontend/src/components/editor/article-mentions-plugin.tsx
+++ b/src/frontend/src/components/editor/article-mentions-plugin.tsx
@@ -1,0 +1,258 @@
+import { type JSX, useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  MenuOption,
+  type MenuTextMatch,
+  useBasicTypeaheadTriggerMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { LexicalTypeaheadMenuPlugin } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { TextNode } from "lexical";
+import { BookOpenIcon } from "lucide-react";
+import { $createArticleMentionNode } from "@/components/editor/article-mention-node";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { toQueryString } from "@/utils/formatting";
+
+const TRIGGERS = ["\\$"].join("");
+const VALID_CHARS = "[^\\s\\$]";
+const LENGTH_LIMIT = 75;
+
+const ArticleMentionsRegex = new RegExp(
+  "(^|\\s|\\()(" +
+    "[" +
+    TRIGGERS +
+    "]" +
+    "(" +
+    VALID_CHARS +
+    "{0," +
+    LENGTH_LIMIT +
+    "}" +
+    ")" +
+    ")$",
+);
+
+const SUGGESTION_LIST_LENGTH_LIMIT = 6;
+
+interface ArticleSuggestion {
+  id: number;
+  name: string;
+  title: string;
+  detailPath: string;
+}
+
+interface ArticleSuggestionResponse {
+  items?: ArticleSuggestion[];
+}
+
+const articleSuggestCache = new Map<string, ArticleSuggestion[] | null>();
+
+function useArticleSuggestService(
+  queryString: string | null,
+): ArticleSuggestion[] {
+  const [results, setResults] = useState<ArticleSuggestion[]>([]);
+  const active = queryString != null && queryString.length >= 1;
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const apiBase = "/api/articles";
+    const cacheKey = `${apiBase}:${queryString}`;
+    const cached = articleSuggestCache.get(cacheKey);
+
+    if (cached === null) {
+      return;
+    }
+
+    articleSuggestCache.set(cacheKey, null);
+
+    const queryParams: Record<string, string> = { q: queryString! };
+    const url = `${apiBase}/suggest${toQueryString(queryParams)}`;
+    fetch(url, { credentials: "same-origin", cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) {
+          return { items: [] } as ArticleSuggestionResponse;
+        }
+        return (await response.json()) as ArticleSuggestionResponse;
+      })
+      .then((data) => {
+        const items = data.items || [];
+        articleSuggestCache.set(cacheKey, items);
+        setResults(items);
+      })
+      .catch(() => {
+        articleSuggestCache.set(cacheKey, []);
+        setResults([]);
+      });
+  }, [active, queryString]);
+
+  if (queryString == null) {
+    return [];
+  }
+
+  const apiBase = "/api/articles";
+  const cacheKey = `${apiBase}:${queryString}`;
+  const cached = articleSuggestCache.get(cacheKey);
+  return cached ?? results;
+}
+
+function checkForArticleMention(
+  text: string,
+  minMatchLength: number,
+): MenuTextMatch | null {
+  const match = ArticleMentionsRegex.exec(text);
+  if (match !== null) {
+    const maybeLeadingWhitespace = match[1];
+    const matchingString = match[3];
+    if (matchingString.length >= minMatchLength) {
+      return {
+        leadOffset: match.index + maybeLeadingWhitespace.length,
+        matchingString,
+        replaceableString: match[2],
+      };
+    }
+  }
+  return null;
+}
+
+function getPossibleArticleQueryMatch(text: string): MenuTextMatch | null {
+  return checkForArticleMention(text, 1);
+}
+
+class ArticleTypeaheadOption extends MenuOption {
+  id: number;
+  articleName: string;
+  title: string;
+
+  constructor(id: number, articleName: string, title: string) {
+    super(`${id}-${articleName}`);
+    this.id = id;
+    this.articleName = articleName;
+    this.title = title;
+  }
+}
+
+export function ArticleMentionsPlugin(): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+
+  const [queryString, setQueryString] = useState<string | null>(null);
+
+  const results = useArticleSuggestService(queryString);
+
+  const checkForSlashTriggerMatch = useBasicTypeaheadTriggerMatch("/", {
+    minLength: 0,
+  });
+
+  const options = useMemo(
+    () =>
+      results
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(
+          (result) =>
+            new ArticleTypeaheadOption(result.id, result.name, result.title),
+        )
+        .slice(0, SUGGESTION_LIST_LENGTH_LIMIT),
+    [results],
+  );
+
+  const onSelectOption = useCallback(
+    (
+      selectedOption: ArticleTypeaheadOption,
+      nodeToReplace: TextNode | null,
+      closeMenu: () => void,
+    ) => {
+      editor.update(() => {
+        const articleMentionNode = $createArticleMentionNode(
+          selectedOption.id,
+          selectedOption.articleName,
+          selectedOption.title,
+        );
+        if (nodeToReplace) {
+          nodeToReplace.replace(articleMentionNode);
+        }
+        articleMentionNode.select();
+        closeMenu();
+      });
+    },
+    [editor],
+  );
+
+  const checkForMentionMatch = useCallback(
+    (text: string) => {
+      const slashMatch = checkForSlashTriggerMatch(text, editor);
+      if (slashMatch !== null) {
+        return null;
+      }
+      return getPossibleArticleQueryMatch(text);
+    },
+    [checkForSlashTriggerMatch, editor],
+  );
+
+  return (
+    <LexicalTypeaheadMenuPlugin
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      triggerFn={checkForMentionMatch}
+      options={options}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+      ) => {
+        return anchorElementRef.current && results.length
+          ? createPortal(
+              <div className="absolute z-10 min-w-64 rounded-md shadow-md">
+                <Command
+                  onKeyDown={(e) => {
+                    if (e.key === "ArrowUp") {
+                      e.preventDefault();
+                      setHighlightedIndex(
+                        selectedIndex !== null
+                          ? (selectedIndex - 1 + options.length) %
+                              options.length
+                          : options.length - 1,
+                      );
+                    } else if (e.key === "ArrowDown") {
+                      e.preventDefault();
+                      setHighlightedIndex(
+                        selectedIndex !== null
+                          ? (selectedIndex + 1) % options.length
+                          : 0,
+                      );
+                    }
+                  }}
+                >
+                  <CommandList>
+                    <CommandGroup>
+                      {options.map((option: ArticleTypeaheadOption) => (
+                        <CommandItem
+                          key={option.key}
+                          value={`${option.id} ${option.articleName} ${option.title}`}
+                          onSelect={() => {
+                            selectOptionAndCleanUp(option);
+                          }}
+                        >
+                          <span className="shrink-0 text-red-500">
+                            <BookOpenIcon className="size-4" />
+                          </span>
+                          <span className="truncate font-medium text-sm">
+                            {option.title}
+                          </span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </div>,
+              anchorElementRef.current,
+            )
+          : null;
+      }}
+    />
+  );
+}

--- a/src/frontend/src/components/markdown/MarkdownContent.tsx
+++ b/src/frontend/src/components/markdown/MarkdownContent.tsx
@@ -20,13 +20,18 @@ import rehypeHighlight from "rehype-highlight";
 
 import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
-import type { CrossReferenceEntry } from "@/types/domain/tickets";
+import type {
+  CrossReferenceEntry,
+  ArticleReferenceEntry,
+} from "@/types/domain/tickets";
 import { TicketHoverPreview } from "@/components/tickets/TicketHoverPreview";
+import { ArticleHoverPreview } from "@/components/articles/ArticleHoverPreview";
 
 interface MarkdownContentProps {
   children?: ReactNode;
   className?: string;
   crossReferences?: CrossReferenceEntry[];
+  articleReferences?: ArticleReferenceEntry[];
 }
 
 const markdownLinkClassName =
@@ -91,6 +96,7 @@ function MarkdownCodeBlock({
 
 function buildLinkComponent(
   crossReferences?: CrossReferenceEntry[],
+  articleReferences?: ArticleReferenceEntry[],
 ): Components["a"] {
   function MarkdownLink({
     className,
@@ -116,6 +122,25 @@ function buildLinkComponent(
             >
               {children}
             </TicketHoverPreview>
+          );
+        }
+      }
+    }
+    if (articleReferences && href) {
+      const match = href.match(/\/articles\/(\d+)$/);
+      if (match) {
+        const articleId = Number(match[1]);
+        const ref = articleReferences.find((r) => r.articleId === articleId);
+        if (ref) {
+          return (
+            <ArticleHoverPreview
+              articleTitle={ref.articleTitle}
+              articleExcerpt={ref.articleExcerpt}
+              detailPath={ref.detailPath}
+              className={cn(markdownLinkClassName, className)}
+            >
+              {children}
+            </ArticleHoverPreview>
           );
         }
       }
@@ -322,6 +347,7 @@ export default function MarkdownContent({
   children,
   className,
   crossReferences,
+  articleReferences,
 }: MarkdownContentProps) {
   let content = typeof children === "string" ? children : "";
 
@@ -337,9 +363,16 @@ export default function MarkdownContent({
   const blocks = parseMarkdownBlocks(content);
 
   const components = useMemo(() => {
-    if (!crossReferences || crossReferences.length === 0) return undefined;
-    return { ...markdownComponents, a: buildLinkComponent(crossReferences) };
-  }, [crossReferences]);
+    if (
+      (!crossReferences || crossReferences.length === 0) &&
+      (!articleReferences || articleReferences.length === 0)
+    )
+      return undefined;
+    return {
+      ...markdownComponents,
+      a: buildLinkComponent(crossReferences, articleReferences),
+    };
+  }, [crossReferences, articleReferences]);
 
   return (
     <div className={cn("max-w-none text-sm text-foreground", className)}>

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -38,6 +38,7 @@ import type {
   NamedEntity,
   SupportTicketDetailRecord,
   VersionInfo,
+  ArticleReferenceEntry,
 } from "../types/domain";
 import type { SupportTicketDetailState } from "../types/forms";
 import { Button } from "../components/ui/button";
@@ -206,10 +207,12 @@ function TicketMessageCard({
   message,
   enableAttachmentPreviews,
   crossReferences,
+  articleReferences,
 }: {
   message: MessageReference;
   enableAttachmentPreviews: boolean;
   crossReferences?: CrossReferenceEntry[];
+  articleReferences?: ArticleReferenceEntry[];
 }) {
   const author = message.author;
   const authorLabel =
@@ -238,7 +241,10 @@ function TicketMessageCard({
 
       <div className="space-y-4 px-4 py-4">
         <div className="prose prose-sm max-w-none text-foreground dark:prose-invert [&>p:first-child]:mt-0 [&>p:last-child]:mb-0">
-          <MarkdownContent crossReferences={crossReferences}>
+          <MarkdownContent
+            crossReferences={crossReferences}
+            articleReferences={articleReferences}
+          >
             {message.body || ""}
           </MarkdownContent>
         </div>
@@ -321,6 +327,16 @@ export default function SupportTicketDetailPage({
       crossReferences.map((reference) => [reference.ticketId, reference]),
     ).values(),
   ).sort((left, right) => left.ticketName.localeCompare(right.ticketName));
+  const relatedArticles = Array.from(
+    new Map(
+      (refsState.data?.articles ?? []).map((reference) => [
+        reference.articleId,
+        reference,
+      ]),
+    ).values(),
+  ).sort((left, right) =>
+    (left.articleTitle ?? "").localeCompare(right.articleTitle ?? ""),
+  );
 
   useEffect(() => {
     if (!ticket) {
@@ -793,7 +809,36 @@ export default function SupportTicketDetailPage({
                           <div className="text-sm text-muted-foreground">-</div>
                         </Field>
                       )}
-                      <div className="hidden md:block" aria-hidden="true" />
+                      {relatedArticles.length > 0 ? (
+                        <Field>
+                          <FieldLabel>Articles</FieldLabel>
+                          <div className="border rounded-md overflow-hidden">
+                            <Table>
+                              <TableBody>
+                                {relatedArticles.map((ref) => (
+                                  <TableRow key={ref.articleId}>
+                                    <TableCell className="text-sm">
+                                      <a
+                                        href={ref.detailPath}
+                                        className="text-primary underline"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                      >
+                                        {ref.articleTitle}
+                                      </a>
+                                    </TableCell>
+                                  </TableRow>
+                                ))}
+                              </TableBody>
+                            </Table>
+                          </div>
+                        </Field>
+                      ) : (
+                        <Field>
+                          <FieldLabel>Articles</FieldLabel>
+                          <div className="text-sm text-muted-foreground">-</div>
+                        </Field>
+                      )}
                     </>
                   );
                 })()}
@@ -846,6 +891,7 @@ export default function SupportTicketDetailPage({
                         message={message}
                         enableAttachmentPreviews={enableAttachmentPreviews}
                         crossReferences={crossReferences}
+                        articleReferences={relatedArticles}
                       />
                     ))}
                 </div>

--- a/src/frontend/src/types/domain/tickets.ts
+++ b/src/frontend/src/types/domain/tickets.ts
@@ -109,7 +109,16 @@ export interface CrossReferenceEntry {
   levelName: string | null;
 }
 
+export interface ArticleReferenceEntry {
+  articleId: Id;
+  articleName: string;
+  articleTitle: string;
+  articleExcerpt: string;
+  detailPath: string;
+}
+
 export interface CrossReferencesResponse {
   references: CrossReferenceEntry[];
   referencedBy: CrossReferenceEntry[];
+  articles: ArticleReferenceEntry[];
 }


### PR DESCRIPTION
- Adds `$` mention support in the message editor. Typing `$` opens a suggestion list of articles filtered live as you type.
- Selecting one inserts a styled mention that links to the referenced article with a hover preview.
- `Articles` are shown in a dedicated section in the ticket header.
- Ticket PDF export includes an `Articles` section as well.

<img width="294" height="197" alt="Screenshot from 2026-05-05 01-26-09" src="https://github.com/user-attachments/assets/92817c7d-3245-456d-9694-0646c06fa2ab" />

<img width="1786" height="912" alt="Screenshot from 2026-05-05 00-53-41" src="https://github.com/user-attachments/assets/78f6ca25-8fb8-4970-95ae-b0f0a4ac3c4a" />

<img width="893" height="217" alt="Screenshot from 2026-05-05 01-27-08" src="https://github.com/user-attachments/assets/8cab5035-3917-4044-8790-5817ec93e6e6" />


Closes #114 