### PR TITLE
[#22] Event system: loose keys and lifecycle events

### DIFF
--- a/doc/manual/en/72-architecture.md
+++ b/doc/manual/en/72-architecture.md
@@ -169,6 +169,16 @@ erDiagram
         BIGINT entitlement_id PK, FK
         BIGINT support_level_id PK, FK
     }
+    
+    EVENTS {
+        BIGINT id PK
+        BIGINT event_type
+        TIMESTAMP created_at
+        BIGINT entity_id
+        BIGINT company_id
+        BIGINT user_id
+        STRING event_value
+    }
 
     COUNTRY ||--o{ TIMEZONE : has
     COUNTRY ||--o{ COMPANY : locates

--- a/doc/manual/en/74-events.md
+++ b/doc/manual/en/74-events.md
@@ -1,0 +1,71 @@
+\newpage
+
+# Events
+
+## Overview
+
+The event system tracks all changes made to an entity throughout its lifecycle.
+Every time an entity is created or updated, the system records an event that captures
+what changed, who made the change, and when it happened.
+
+Events are a loose audit ledger: `key` points at the entity identified by the event type rather than being a database foreign-key relationship. This preserves history after deletion and supports every domain entity in the same table.
+
+---
+
+## Event Types
+
+Event types are grouped into constants defined in `EventConstants.java`. For tickets, they are:
+
+### TICKET_STATUS_CHANGED (1L)
+
+An action event is recorded when the **status of a ticket changes**.
+The new status value (e.g., `OPEN`, `ASSIGNED`, `IN PROGRESS`, `RESOLVED`, `CLOSED`) is stored in the `event_value` payload field of the event.
+
+### TICKET_CATEGORY_CHANGED (2L)
+
+A category event is recorded when the **category of a ticket changes**.
+The new category name (e.g., `BUG`, `FEATURE`, `QUESTION`) is stored in the `event_value` payload field of the event.
+
+---
+
+## How It Works
+
+Events are triggered in two scenarios for a **Ticket**:
+
+**1. Ticket Created**
+When a user creates a new ticket, the system records:
+- A `TICKET_STATUS_CHANGED` event (value e.g. `OPEN`)
+- A `TICKET_CATEGORY_CHANGED` event matching the ticket's initial category (e.g. `BUG`)
+
+**2. Ticket Updated**
+When a support user updates a ticket, the system compares the ticket's current state
+against the last recorded event for each type. A new event is only saved if something
+has actually changed.
+
+```text
+Ticket updated
+     │
+     ├── Has the status changed since the last STATUS event?
+     │        └── Yes → Save a new TICKET_STATUS_CHANGED event
+     │
+     └── Has the category changed since the last CATEGORY event?
+              └── Yes → Save a new TICKET_CATEGORY_CHANGED event
+```
+
+---
+
+## Event Structure
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | Long | Unique identifier |
+| `eventType` | Long | The classification of the event (e.g. `1` for status change) |
+| `key` | Long / bigint | Loose ID of the entity identified by `eventType` |
+| `companyId` | Long | Optional company scope, indexed for reporting |
+| `userId` | Long | The ID of the user who triggered the event |
+| `eventValue` | String | The payload/value of the change (e.g. `OPEN`) |
+| `createdAt` | LocalDateTime | Timestamp of when the event was recorded |
+
+Ticket lifecycle events include opening, assignment, resolution, closure, deletion, status/category changes, and user-association changes. Message creation is also recorded with the message as its key. Every domain entity has `*_CREATED` and `*_DELETED` constants so workflows can record them without new tables or hard foreign keys.
+
+---

--- a/src/backend/main/java/ai/mnemosyne_systems/model/event/Event.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/model/event/Event.java
@@ -1,0 +1,47 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+package ai.mnemosyne_systems.model.event;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "events", indexes = { @Index(name = "idx_events_company_id", columnList = "company_id"),
+        @Index(name = "idx_events_key_type_created_at", columnList = "event_key,event_type,created_at") })
+public class Event extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    @Column(name = "event_type")
+    public Long eventType;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    public LocalDateTime createdAt;
+
+    /**
+     * Loose foreign key. Its target is determined by {@link #eventType}; it is a bigint in the database rather than a
+     * JPA relationship on purpose.
+     */
+    @Column(name = "event_key")
+    public Long key;
+
+    @Column(name = "company_id")
+    public Long companyId;
+
+    @Column(name = "user_id")
+    public Long userId;
+
+    @Column(name = "event_value")
+    public String eventValue;
+}

--- a/src/backend/main/java/ai/mnemosyne_systems/model/event/EventConstants.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/model/event/EventConstants.java
@@ -1,0 +1,68 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.model.event;
+
+public class EventConstants {
+    private EventConstants() {
+    }
+
+    // Ticket lifecycle and changes
+    public static final long TICKET_STATUS_CHANGED = 1L;
+    public static final long TICKET_CATEGORY_CHANGED = 2L;
+    public static final long TICKET_OPENED = 3L;
+    public static final long TICKET_CREATED = TICKET_OPENED;
+    public static final long TICKET_ASSIGNED = 4L;
+    public static final long TICKET_RESOLVED = 5L;
+    public static final long TICKET_CLOSED = 6L;
+    public static final long TICKET_DELETED = 7L;
+    public static final long TICKET_SUPPORT_USER_ADDED = 8L;
+    public static final long TICKET_SUPPORT_USER_REMOVED = 9L;
+    public static final long TICKET_TAM_ADDED = 10L;
+    public static final long TICKET_TAM_REMOVED = 11L;
+    public static final long TICKET_EXTERNAL_USER_ADDED = 12L;
+    public static final long TICKET_EXTERNAL_USER_REMOVED = 13L;
+    public static final long TICKET_PARTICIPANT_ADDED = 14L;
+    public static final long TICKET_PARTICIPANT_REMOVED = 15L;
+
+    // Entity lifecycle events. The event key is the primary key of the named entity.
+    public static final long ARTICLE_CREATED = 100L;
+    public static final long ARTICLE_DELETED = 101L;
+    public static final long ATTACHMENT_CREATED = 102L;
+    public static final long ATTACHMENT_DELETED = 103L;
+    public static final long CATEGORY_CREATED = 104L;
+    public static final long CATEGORY_DELETED = 105L;
+    public static final long COMPANY_CREATED = 106L;
+    public static final long COMPANY_DELETED = 107L;
+    public static final long COMPANY_ENTITLEMENT_CREATED = 108L;
+    public static final long COMPANY_ENTITLEMENT_DELETED = 109L;
+    public static final long COUNTRY_CREATED = 110L;
+    public static final long COUNTRY_DELETED = 111L;
+    public static final long CROSS_REFERENCE_CREATED = 112L;
+    public static final long CROSS_REFERENCE_DELETED = 113L;
+    public static final long ENTITLEMENT_CREATED = 114L;
+    public static final long ENTITLEMENT_DELETED = 115L;
+    public static final long INSTALLATION_CREATED = 116L;
+    public static final long INSTALLATION_DELETED = 117L;
+    public static final long LEVEL_CREATED = 118L;
+    public static final long LEVEL_DELETED = 119L;
+    public static final long MESSAGE_CREATED = 120L;
+    public static final long MESSAGE_DELETED = 121L;
+    public static final long PASSWORD_RESET_TOKEN_CREATED = 122L;
+    public static final long PASSWORD_RESET_TOKEN_DELETED = 123L;
+    public static final long TICKET_IMPORT_BATCH_CREATED = 124L;
+    public static final long TICKET_IMPORT_BATCH_DELETED = 125L;
+    public static final long TICKET_IMPORT_RECORD_CREATED = 126L;
+    public static final long TICKET_IMPORT_RECORD_DELETED = 127L;
+    public static final long TIMEZONE_CREATED = 128L;
+    public static final long TIMEZONE_DELETED = 129L;
+    public static final long USER_CREATED = 130L;
+    public static final long USER_DELETED = 131L;
+    public static final long VERSION_CREATED = 132L;
+    public static final long VERSION_DELETED = 133L;
+}

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ArticleResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ArticleResource.java
@@ -41,6 +41,9 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class ArticleResource {
+    @jakarta.inject.Inject
+    ai.mnemosyne_systems.service.EventService eventService;
+
     private static final String SAMPLE_TITLE = "Getting Started Guide";
     private static final String SAMPLE_TAGS = "guide, onboarding";
     private static final String SAMPLE_BODY = "## Welcome to billetsys\n\n- Open a ticket from the Tickets menu\n- Use Markdown in messages\n- Attach files with the attachment picker";
@@ -97,6 +100,8 @@ public class ArticleResource {
         article.tags = tags == null ? null : tags.trim();
         article.body = body.trim();
         article.persist();
+        eventService.record(article.id, ai.mnemosyne_systems.model.event.EventConstants.ARTICLE_CREATED, null,
+                AuthHelper.findUser(auth).id, "Article created");
         List<Attachment> attachments = storeAttachments(article,
                 AttachmentHelper.readAttachments(input, "attachments"));
         article.body = resolveInlineAttachmentUrls(article.body, attachments);
@@ -139,6 +144,8 @@ public class ArticleResource {
         if (article == null) {
             throw new NotFoundException();
         }
+        eventService.record(article.id, ai.mnemosyne_systems.model.event.EventConstants.ARTICLE_DELETED, null,
+                AuthHelper.findUser(auth).id, "Article deleted");
         article.delete();
         return ReactRedirectSupport.redirect(client, "/articles");
     }
@@ -148,6 +155,8 @@ public class ArticleResource {
             upload.message = null;
             upload.article = article;
             upload.persist();
+            eventService.record(upload.id, ai.mnemosyne_systems.model.event.EventConstants.ATTACHMENT_CREATED, null,
+                    null, "Attachment created");
             article.attachments.add(upload);
         }
         Panache.getEntityManager().flush();

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/CategoryResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/CategoryResource.java
@@ -40,6 +40,8 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class CategoryResource {
+    @jakarta.inject.Inject
+    ai.mnemosyne_systems.service.EventService eventService;
 
     @GET
     public Response list(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
@@ -95,6 +97,8 @@ public class CategoryResource {
         category.description = description == null ? "" : description.trim();
         category.isDefault = makeDefault;
         category.persist();
+        eventService.record(category.id, ai.mnemosyne_systems.model.event.EventConstants.CATEGORY_CREATED, null,
+                AuthHelper.findUser(auth).id, "Category created");
         List<Attachment> attachments = storeAttachments(category,
                 AttachmentHelper.readAttachments(input, "attachments"));
         category.description = resolveInlineAttachmentUrls(category.description, attachments);
@@ -162,6 +166,8 @@ public class CategoryResource {
             throw new NotFoundException();
         }
         Attachment.delete("category", category);
+        eventService.record(category.id, ai.mnemosyne_systems.model.event.EventConstants.CATEGORY_DELETED, null,
+                AuthHelper.findUser(auth).id, "Category deleted");
         category.delete();
         return ReactRedirectSupport.redirect(client, "/categories");
     }
@@ -172,6 +178,8 @@ public class CategoryResource {
             upload.article = null;
             upload.category = category;
             upload.persist();
+            eventService.record(upload.id, ai.mnemosyne_systems.model.event.EventConstants.ATTACHMENT_CREATED, null,
+                    null, "Attachment created");
             category.attachments.add(upload);
         }
         Panache.getEntityManager().flush();

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/CompanyResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/CompanyResource.java
@@ -45,6 +45,8 @@ import java.util.List;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class CompanyResource {
+    @jakarta.inject.Inject
+    ai.mnemosyne_systems.service.EventService eventService;
 
     @GET
     public Response listCompanies(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
@@ -109,6 +111,8 @@ public class CompanyResource {
         company.users = resolveUsers(userIds, tamIds, null);
         company.phoneNumber = phoneNumber;
         company.persist();
+        eventService.record(company.id, ai.mnemosyne_systems.model.event.EventConstants.COMPANY_CREATED, company.id,
+                AuthHelper.findUser(auth).id, "Company created");
         applyEntitlements(company, entitlementIds, levelIds, entitlementDates, entitlementDurations,
                 java.util.List.of());
         return ReactRedirectSupport.redirect(client, "/companies");
@@ -164,6 +168,8 @@ public class CompanyResource {
             if (Ticket.count("companyEntitlement", entry) > 0) {
                 continue;
             }
+            eventService.record(entry.id, ai.mnemosyne_systems.model.event.EventConstants.COMPANY_ENTITLEMENT_DELETED,
+                    company.id, AuthHelper.findUser(auth).id, "Company entitlement deleted");
             entry.delete();
         }
         return ReactRedirectSupport.redirect(client, "/companies");
@@ -179,6 +185,8 @@ public class CompanyResource {
         if (company == null) {
             throw new NotFoundException();
         }
+        eventService.record(company.id, ai.mnemosyne_systems.model.event.EventConstants.COMPANY_DELETED, company.id,
+                AuthHelper.findUser(auth).id, "Company deleted");
         company.delete();
         return ReactRedirectSupport.redirect(client, "/companies");
     }
@@ -268,6 +276,9 @@ public class CompanyResource {
                 entry.date = entitlementDate;
                 entry.duration = entitlementDuration;
                 entry.persist();
+                eventService.record(entry.id,
+                        ai.mnemosyne_systems.model.event.EventConstants.COMPANY_ENTITLEMENT_CREATED, company.id, null,
+                        "Company entitlement created");
             }
         }
         return selectedEntitlementPairs;

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/EntitlementResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/EntitlementResource.java
@@ -42,6 +42,9 @@ import java.util.Map;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class EntitlementResource {
+    @jakarta.inject.Inject
+    ai.mnemosyne_systems.service.EventService eventService;
+
     @GET
     public Response listEntitlements(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
         requireAdmin(auth);
@@ -92,6 +95,8 @@ public class EntitlementResource {
         entitlement.versions.clear();
         entitlement.versions.addAll(resolveVersions(entitlement, null, versionIds, versionNames, versionDates));
         entitlement.persist();
+        eventService.record(entitlement.id, ai.mnemosyne_systems.model.event.EventConstants.ENTITLEMENT_CREATED, null,
+                AuthHelper.findUser(auth).id, "Entitlement created");
         return ReactRedirectSupport.redirect(client, "/entitlements");
     }
 
@@ -131,6 +136,8 @@ public class EntitlementResource {
         if (entitlement == null) {
             throw new NotFoundException();
         }
+        eventService.record(entitlement.id, ai.mnemosyne_systems.model.event.EventConstants.ENTITLEMENT_DELETED, null,
+                AuthHelper.findUser(auth).id, "Entitlement deleted");
         entitlement.delete();
         return ReactRedirectSupport.redirect(client, "/entitlements");
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserResource.java
@@ -27,6 +27,8 @@ import java.util.UUID;
 @Produces(MediaType.TEXT_HTML)
 @io.smallrye.common.annotation.Blocking
 public class ExternalUserResource {
+    @jakarta.inject.Inject
+    ai.mnemosyne_systems.service.EventService eventService;
 
     @POST
     @Path("{role}/externals")
@@ -79,6 +81,8 @@ public class ExternalUserResource {
         }
 
         user.persist();
+        eventService.record(user.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED,
+                company == null ? null : company.id, AuthHelper.findUser(auth).id, "User created");
         company.users.add(user);
 
         return Response.seeOther(URI.create("/" + role + "/externals")).build();
@@ -152,6 +156,8 @@ public class ExternalUserResource {
         }
 
         userCompany.users.remove(user);
+        eventService.record(user.id, ai.mnemosyne_systems.model.event.EventConstants.USER_DELETED, null,
+                AuthHelper.findUser(auth).id, "User deleted");
         user.delete();
 
         return Response.seeOther(URI.create("/" + role + "/externals")).build();

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/LevelResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/LevelResource.java
@@ -37,6 +37,9 @@ import java.util.List;
 @Produces(MediaType.TEXT_HTML)
 @Blocking
 public class LevelResource {
+    @jakarta.inject.Inject
+    ai.mnemosyne_systems.service.EventService eventService;
+
     public static final class ColorOption {
         private final String value;
         private final String label;
@@ -123,6 +126,8 @@ public class LevelResource {
         level.timezone = timezoneId != null ? Timezone.findById(timezoneId)
                 : Timezone.find("name", "America/New_York").firstResult();
         level.persist();
+        eventService.record(level.id, ai.mnemosyne_systems.model.event.EventConstants.LEVEL_CREATED, null,
+                AuthHelper.findUser(auth).id, "Level created");
         return ReactRedirectSupport.redirect(client, "/levels");
     }
 
@@ -176,6 +181,8 @@ public class LevelResource {
         if (level == null) {
             throw new NotFoundException();
         }
+        eventService.record(level.id, ai.mnemosyne_systems.model.event.EventConstants.LEVEL_DELETED, null,
+                AuthHelper.findUser(auth).id, "Level deleted");
         level.delete();
         return ReactRedirectSupport.redirect(client, "/levels");
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
@@ -19,6 +19,7 @@ import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
 import ai.mnemosyne_systems.service.CrossReferenceService;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -46,7 +47,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -67,6 +67,9 @@ public class SuperuserResource {
 
     @Inject
     TicketEmailService ticketEmailService;
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("superuser")
@@ -139,6 +142,8 @@ public class SuperuserResource {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
         }
         newUser.persist();
+        eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, company.id,
+                user.id, "User created");
         addUserIfMissing(company, newUser);
         return Response.seeOther(URI.create("/superuser/users/" + company.id)).build();
     }
@@ -218,6 +223,7 @@ public class SuperuserResource {
         ticket.category = categoryId != null ? Category.findById(categoryId) : Category.findDefault();
         ticket.persist();
         boolean isPublic = AttachmentHelper.readFormBoolean(input, "isPublic", true);
+        eventService.saveTicketEvent(ticket, ticket.requester);
         Message message = new Message();
         message.body = messageBody.trim();
         message.date = LocalDateTime.now();
@@ -227,6 +233,7 @@ public class SuperuserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         crossReferenceService.extractAndSaveReferences(message, null);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
@@ -321,6 +328,7 @@ public class SuperuserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         crossReferenceService.extractAndSaveReferences(message, null);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
@@ -356,6 +364,7 @@ public class SuperuserResource {
         ticket.title = normalizedTitle;
         ticket.affectsVersion = resolveVersionForTicket(ticket, affectsVersionId, "Affects");
         ticket.resolvedVersion = resolveOptionalVersionForTicket(ticket, resolvedVersionId, "Resolved");
+        eventService.saveTicketEvent(ticket, user);
         return ReactRedirectSupport.redirect(client, "/superuser/tickets/" + id);
     }
 

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserTicketApiResource.java
@@ -16,7 +16,9 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.model.event.Event;
 import ai.mnemosyne_systems.service.CrossReferenceService;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -46,6 +48,9 @@ public class SuperuserTicketApiResource {
 
     @Inject
     SuperuserResource superuserResource;
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Transactional
@@ -174,6 +179,9 @@ public class SuperuserTicketApiResource {
 
         java.util.Map<Long, Ticket> ticketCache = crossReferenceService
                 .preloadReferencedTickets(messages.stream().map(m -> m.body).toList());
+        List<Event> rawEvents = eventService.getAllChangesToEntity(ticket.id);
+        List<SupportTicketApiResource.EventEntry> eventEntries = rawEvents.stream().map(this::toEventEntry).toList();
+
         return new UserTicketApiResource.RoleTicketDetailResponse(ticket.id, ticket.name, ticket.displayTitle(),
                 normalizeDisplayStatus(ticket.status), data.assignedTickets == null ? 0 : data.assignedTickets.size(),
                 data.openTickets == null ? 0 : data.openTickets.size(),
@@ -198,7 +206,7 @@ public class SuperuserTicketApiResource {
                 "/superuser/tickets/" + ticket.id + "/messages", "/tickets/export/" + ticket.id,
                 List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"), false, false, false, true, true,
                 externalUsers.stream().map(this::toUserReference).toList(),
-                userUsers.stream().map(this::toUserReference).toList());
+                userUsers.stream().map(this::toUserReference).toList(), eventEntries);
     }
 
     @GET
@@ -340,5 +348,12 @@ public class SuperuserTicketApiResource {
             throw new NotAuthorizedException(Response.status(Response.Status.UNAUTHORIZED).build());
         }
         return user;
+    }
+
+    private SupportTicketApiResource.EventEntry toEventEntry(Event event) {
+        User user = event.userId == null ? null : User.findById(event.userId);
+        return new SupportTicketApiResource.EventEntry(event.id, event.eventType == null ? null : event.eventValue,
+                event.createdAt == null ? null : SupportTicketViewSupport.formatDate(event.createdAt),
+                user == null ? null : toUserReference(user));
     }
 }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
@@ -18,7 +18,9 @@ import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
+import ai.mnemosyne_systems.model.event.EventConstants;
 import ai.mnemosyne_systems.service.CrossReferenceService;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -45,11 +47,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
@@ -64,6 +62,8 @@ public class SupportResource {
 
     @Inject
     TicketEmailService ticketEmailService;
+    @Inject
+    EventService eventService;
 
     @GET
     public Response listTickets(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
@@ -224,6 +224,8 @@ public class SupportResource {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
         }
         newUser.persist();
+        eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, company.id,
+                AuthHelper.findUser(auth).id, "User created");
         boolean exists = company.users.stream()
                 .anyMatch(existing -> existing.id != null && existing.id.equals(newUser.id));
         if (!exists) {
@@ -288,10 +290,12 @@ public class SupportResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         crossReferenceService.extractAndSaveReferences(message, null);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         if (ticket.supportUsers.stream().noneMatch(existing -> existing.id != null && existing.id.equals(user.id))) {
             ticket.supportUsers.add(user);
+            eventService.recordTicketUserAssociation(ticket, user, user, EventConstants.TICKET_SUPPORT_USER_ADDED);
         }
         if (ticket.status == null || ticket.status.isBlank() || "Open".equalsIgnoreCase(ticket.status)) {
             ticket.status = "Assigned";
@@ -299,6 +303,7 @@ public class SupportResource {
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
+        eventService.saveTicketEvent(ticket, user);
         ticketEmailService.notifyMessageChange(ticket, message, user);
         return Response.seeOther(URI.create("/support/tickets/" + id + "?replyAdded=1")).build();
     }
@@ -354,6 +359,7 @@ public class SupportResource {
         ticket.affectsVersion = resolveVersion(entitlement, affectsVersionId, "Affects", true);
         ticket.category = categoryId != null ? Category.findById(categoryId) : Category.findDefault();
         ticket.persist();
+        eventService.saveTicketEvent(ticket, user);
         assignCompanyTams(ticket);
         boolean isPublic = AttachmentHelper.readFormBoolean(input, "isPublic", true);
         Message message = new Message();
@@ -365,6 +371,7 @@ public class SupportResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
         return createTicketRedirect(client, "/support/tickets/" + ticket.id);
@@ -429,12 +436,14 @@ public class SupportResource {
                     .anyMatch(existing -> existing.id != null && existing.id.equals(user.id));
             if (!assigned) {
                 ticket.supportUsers.add(user);
+                eventService.recordTicketUserAssociation(ticket, user, user, EventConstants.TICKET_SUPPORT_USER_ADDED);
             }
         }
         assignCompanyTams(ticket);
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
+        eventService.saveTicketEvent(ticket, user);
         return createTicketRedirect(client, "/support/tickets/" + id);
     }
 
@@ -451,6 +460,7 @@ public class SupportResource {
         String previousStatus = ticketEmailService.computeEffectiveStatus(ticket, ticket.status);
         if (ticket.supportUsers.stream().noneMatch(existing -> existing.id != null && existing.id.equals(user.id))) {
             ticket.supportUsers.add(user);
+            eventService.recordTicketUserAssociation(ticket, user, user, EventConstants.TICKET_SUPPORT_USER_ADDED);
         }
         if (ticket.status == null || ticket.status.isBlank() || "Open".equalsIgnoreCase(ticket.status)) {
             ticket.status = "Assigned";
@@ -459,6 +469,7 @@ public class SupportResource {
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
+        eventService.saveTicketEvent(ticket, user);
         return createTicketRedirect(client, "/support/tickets/" + id);
     }
 
@@ -483,6 +494,7 @@ public class SupportResource {
         for (User tam : tams) {
             if (tam.id != null && !existingIds.contains(tam.id)) {
                 ticket.tamUsers.add(tam);
+                eventService.recordTicketUserAssociation(ticket, null, tam, EventConstants.TICKET_TAM_ADDED);
             }
         }
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketApiResource.java
@@ -18,11 +18,14 @@ import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
 import ai.mnemosyne_systems.service.CrossReferenceService;
 import ai.mnemosyne_systems.util.AuthHelper;
+import ai.mnemosyne_systems.model.event.Event;
+import ai.mnemosyne_systems.service.EventService;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
@@ -44,6 +47,8 @@ public class SupportTicketApiResource {
 
     @Inject
     CrossReferenceService crossReferenceService;
+    @Inject
+    EventService eventService;
 
     @GET
     @Transactional
@@ -163,6 +168,8 @@ public class SupportTicketApiResource {
         java.util.Map<Long, Ticket> ticketCache = crossReferenceService
                 .preloadReferencedTickets(messages.stream().map(m -> m.body).toList());
         List<MessageEntry> messageEntries = messages.stream().map(m -> toMessageEntry(m, ticketCache)).toList();
+        List<Event> rawEvents = eventService.getAllChangesToEntity(ticket.id);
+        List<EventEntry> eventEntries = rawEvents.stream().map(this::toEventEntry).toList();
         return new SupportTicketDetailResponse(ticket.id, ticket.name, ticket.displayTitle(), displayStatus,
                 counts.assignedCount(), counts.openCount(), ticket.company == null ? null : ticket.company.id,
                 ticket.company == null ? null : ticket.company.name,
@@ -187,7 +194,7 @@ public class SupportTicketApiResource {
                 SupportTicketViewSupport.isEntitlementExpired(ticket), "/support/tickets/" + ticket.id,
                 "/support/tickets/" + ticket.id + "/messages", "/tickets/export/" + ticket.id,
                 List.of("Open", "Assigned", "In Progress", "Waiting for External Feedback", "Resolved", "Closed"),
-                externalUsers.stream().map(this::toUserReference).toList());
+                externalUsers.stream().map(this::toUserReference).toList(), eventEntries);
     }
 
     @GET
@@ -285,6 +292,13 @@ public class SupportTicketApiResource {
                 message.author == null ? null : toUserReference(message.author), message.isPublic,
                 message.attachments == null ? List.of()
                         : message.attachments.stream().map(this::toAttachmentEntry).toList());
+    }
+
+    private EventEntry toEventEntry(Event event) {
+        User user = event.userId == null ? null : User.findById(event.userId);
+        return new EventEntry(event.id, event.eventType == null ? null : event.eventValue,
+                event.createdAt == null ? null : SupportTicketViewSupport.formatDate(event.createdAt),
+                user == null ? null : toUserReference(user));
     }
 
     private AttachmentEntry toAttachmentEntry(Attachment attachment) {
@@ -431,6 +445,9 @@ public class SupportTicketApiResource {
             boolean isPublic, List<AttachmentEntry> attachments) {
     }
 
+    public record EventEntry(Long id, String action, String dateLabel, UserReference user) {
+    }
+
     public record AttachmentEntry(Long id, String name, String mimeType, String sizeLabel, String downloadPath) {
     }
 
@@ -441,6 +458,6 @@ public class SupportTicketApiResource {
             List<VersionOption> versions, List<CategoryOption> categories, List<UserReference> supportUsers,
             List<UserReference> tamUsers, List<MessageEntry> messages, boolean ticketEntitlementExpired,
             String actionPath, String messageActionPath, String exportPath, List<String> statusOptions,
-            List<UserReference> externalUsers) {
+            List<UserReference> externalUsers, List<EventEntry> events) {
     }
 }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/TicketExternalUsersApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/TicketExternalUsersApiResource.java
@@ -11,6 +11,8 @@ package ai.mnemosyne_systems.resource;
 import ai.mnemosyne_systems.model.Company;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import jakarta.transaction.Transactional;
@@ -30,6 +32,9 @@ import jakarta.ws.rs.FormParam;
 @Path("/api/{role}/tickets/{ticketId}/externals")
 @Produces(MediaType.APPLICATION_JSON)
 public class TicketExternalUsersApiResource {
+
+    @jakarta.inject.Inject
+    EventService eventService;
 
     @POST
     @Path("/add")
@@ -63,6 +68,8 @@ public class TicketExternalUsersApiResource {
             externalUser.type = User.TYPE_EXTERNAL;
             externalUser.passwordHash = User.DISABLED_PASSWORD_HASH;
             externalUser.persist();
+            eventService.record(externalUser.id, EventConstants.USER_CREATED,
+                    roleCompany == null ? null : roleCompany.id, currentUser.id, "User created");
 
             // Link to company
             roleCompany.users.add(externalUser);
@@ -76,6 +83,8 @@ public class TicketExternalUsersApiResource {
 
         if (!ticket.externalUsers.contains(externalUser)) {
             ticket.externalUsers.add(externalUser);
+            eventService.recordTicketUserAssociation(ticket, currentUser, externalUser,
+                    EventConstants.TICKET_EXTERNAL_USER_ADDED);
         }
 
         return Response.seeOther(URI.create("/api/" + role + "/tickets/" + ticket.id)).build();
@@ -106,6 +115,8 @@ public class TicketExternalUsersApiResource {
         }
 
         ticket.externalUsers.remove(externalUser);
+        eventService.recordTicketUserAssociation(ticket, currentUser, externalUser,
+                EventConstants.TICKET_EXTERNAL_USER_REMOVED);
 
         return Response.seeOther(URI.create("/api/" + role + "/tickets/" + ticket.id)).build();
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/TicketParticipantUsersApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/TicketParticipantUsersApiResource.java
@@ -11,6 +11,8 @@ package ai.mnemosyne_systems.resource;
 import ai.mnemosyne_systems.model.Company;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import jakarta.transaction.Transactional;
@@ -30,6 +32,9 @@ import jakarta.ws.rs.FormParam;
 @Path("/api/{role}/tickets/{ticketId}/participants")
 @Produces(MediaType.APPLICATION_JSON)
 public class TicketParticipantUsersApiResource {
+
+    @jakarta.inject.Inject
+    EventService eventService;
 
     @POST
     @Path("/add")
@@ -68,6 +73,8 @@ public class TicketParticipantUsersApiResource {
             participantUser.type = User.TYPE_PARTICIPANT;
             participantUser.passwordHash = User.DISABLED_PASSWORD_HASH;
             participantUser.persist();
+            eventService.record(participantUser.id, EventConstants.USER_CREATED,
+                    roleCompany == null ? null : roleCompany.id, currentUser.id, "User created");
 
             // Link to company
             roleCompany.users.add(participantUser);
@@ -82,6 +89,8 @@ public class TicketParticipantUsersApiResource {
 
         if (!ticket.userUsers.contains(participantUser)) {
             ticket.userUsers.add(participantUser);
+            eventService.recordTicketUserAssociation(ticket, currentUser, participantUser,
+                    EventConstants.TICKET_PARTICIPANT_ADDED);
         }
 
         return Response.seeOther(URI.create("/api/" + role + "/tickets/" + ticket.id)).build();
@@ -117,6 +126,8 @@ public class TicketParticipantUsersApiResource {
         }
 
         ticket.userUsers.remove(participantUser);
+        eventService.recordTicketUserAssociation(ticket, currentUser, participantUser,
+                EventConstants.TICKET_PARTICIPANT_REMOVED);
 
         return Response.seeOther(URI.create("/api/" + role + "/tickets/" + ticket.id)).build();
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/TicketResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/TicketResource.java
@@ -15,6 +15,7 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.service.PdfService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -79,6 +80,9 @@ public class TicketResource {
 
     @Inject
     PdfService pdfService;
+
+    @Inject
+    EventService eventService;
 
     @GET
     public Response list(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
@@ -192,6 +196,7 @@ public class TicketResource {
         ticket.affectsVersion = defaultAffectsVersion(entitlement);
         ticket.category = category;
         ticket.persist();
+        eventService.saveTicketEvent(ticket, user);
         return ReactRedirectSupport.redirect(client, "/tickets");
     }
 
@@ -245,9 +250,11 @@ public class TicketResource {
         ticket.category = categoryId != null ? Category.findById(categoryId) : null;
         ticket.externalIssueLink = externalIssueLink != null && !externalIssueLink.isBlank() ? externalIssueLink.trim()
                 : null;
+
         if (!sameStatus(previousStatus, ticket.status)) {
             ticketEmailService.notifyStatusChange(ticket, previousStatus, user);
         }
+        eventService.saveTicketEvent(ticket, user);
         return ReactRedirectSupport.redirect(client, "/tickets");
     }
 
@@ -256,11 +263,12 @@ public class TicketResource {
     @Transactional
     public Response delete(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
             @HeaderParam("X-Billetsys-Client") String client, @PathParam("id") Long id) {
-        requireSupport(auth);
+        User user = requireSupport(auth);
         Ticket ticket = Ticket.findById(id);
         if (ticket == null) {
             throw new NotFoundException();
         }
+        eventService.recordTicketDeleted(ticket, user);
         ticket.delete();
         return ReactRedirectSupport.redirect(client, "/tickets");
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -19,6 +19,7 @@ import ai.mnemosyne_systems.model.Version;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.service.CrossReferenceService;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -43,8 +44,6 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +59,9 @@ public class UserResource {
 
     @Inject
     TicketEmailService ticketEmailService;
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("user")
@@ -175,6 +177,8 @@ public class UserResource {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
         }
         newUser.persist();
+        eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, company.id,
+                AuthHelper.findUser(auth).id, "User created");
         boolean exists = company.users.stream()
                 .anyMatch(existing -> existing.id != null && existing.id.equals(newUser.id));
         if (!exists) {
@@ -248,6 +252,7 @@ public class UserResource {
         ticket.category = categoryId != null ? Category.findById(categoryId) : Category.findDefault();
         ticket.persist();
         boolean isPublic = AttachmentHelper.readFormBoolean(input, "isPublic", true);
+        eventService.saveTicketEvent(ticket, user);
         Message message = new Message();
         message.body = messageBody.trim();
         message.date = java.time.LocalDateTime.now();
@@ -257,6 +262,7 @@ public class UserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, user);
         return createTicketRedirect(client, "/user/tickets/" + ticket.id);
@@ -376,6 +382,7 @@ public class UserResource {
         List<Attachment> attachments = AttachmentHelper.readAttachments(input, "attachments");
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         SupportTicketData data = buildTicketDataForUser(user);
         java.util.Set<Long> accessibleIds = TicketSearchSupport
                 .combineTickets(data.assignedTickets, data.openTickets, data.closedTickets).stream().map(t -> t.id)
@@ -417,6 +424,7 @@ public class UserResource {
         if (User.TYPE_TAM.equalsIgnoreCase(user.type)) {
             ticket.resolvedVersion = resolveOptionalVersionForTicket(ticket, resolvedVersionId, "Resolved");
         }
+        eventService.saveTicketEvent(ticket, user);
         return ReactRedirectSupport.redirect(client, "/user/tickets/" + id);
     }
 
@@ -500,6 +508,8 @@ public class UserResource {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
         }
         newUser.persist();
+        eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, null,
+                AuthHelper.findUser(auth).id, "User created");
         if (companyId != null) {
             Company company = Company.findById(companyId);
             if (company != null) {
@@ -573,6 +583,8 @@ public class UserResource {
             throw new NotFoundException();
         }
         removeUserReferences(deleteUser);
+        eventService.record(deleteUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_DELETED, null,
+                AuthHelper.findUser(auth).id, "User deleted");
         deleteUser.delete();
         return ReactRedirectSupport.redirect(client, "/users");
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserTicketApiResource.java
@@ -16,7 +16,9 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.model.event.Event;
 import ai.mnemosyne_systems.service.CrossReferenceService;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -46,6 +48,9 @@ public class UserTicketApiResource {
 
     @Inject
     UserResource userResource;
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Transactional
@@ -178,6 +183,8 @@ public class UserTicketApiResource {
 
         java.util.Map<Long, Ticket> ticketCache = crossReferenceService
                 .preloadReferencedTickets(messages.stream().map(m -> m.body).toList());
+        List<Event> rawEvents = eventService.getAllChangesToEntity(ticket.id);
+        List<SupportTicketApiResource.EventEntry> eventEntries = rawEvents.stream().map(this::toEventEntry).toList();
         return new RoleTicketDetailResponse(ticket.id, ticket.name, ticket.displayTitle(),
                 normalizeDisplayStatus(ticket.status), data.assignedTickets == null ? 0 : data.assignedTickets.size(),
                 data.openTickets == null ? 0 : data.openTickets.size(),
@@ -202,7 +209,7 @@ public class UserTicketApiResource {
                 "/user/tickets/" + ticket.id + "/messages", "/tickets/export/" + ticket.id,
                 List.of("Open", "Assigned", "In Progress", "Resolved", "Closed"), false, false, false, true, tamView,
                 externalUsers.stream().map(this::toUserReference).toList(),
-                userUsers.stream().map(this::toUserReference).toList());
+                userUsers.stream().map(this::toUserReference).toList(), eventEntries);
     }
 
     @GET
@@ -267,6 +274,13 @@ public class UserTicketApiResource {
                 message.author == null ? null : toUserReference(message.author), message.isPublic,
                 message.attachments == null ? List.of()
                         : message.attachments.stream().map(this::toAttachmentEntry).toList());
+    }
+
+    private SupportTicketApiResource.EventEntry toEventEntry(Event event) {
+        User user = event.userId == null ? null : User.findById(event.userId);
+        return new SupportTicketApiResource.EventEntry(event.id, event.eventType == null ? null : event.eventValue,
+                event.createdAt == null ? null : SupportTicketViewSupport.formatDate(event.createdAt),
+                user == null ? null : toUserReference(user));
     }
 
     private SupportTicketApiResource.AttachmentEntry toAttachmentEntry(Attachment attachment) {
@@ -378,6 +392,6 @@ public class UserTicketApiResource {
             String messageActionPath, String exportPath, List<String> statusOptions, boolean editableStatus,
             boolean editableCategory, boolean editableExternalIssue, boolean editableAffectsVersion,
             boolean editableResolvedVersion, List<SupportTicketApiResource.UserReference> externalUsers,
-            List<SupportTicketApiResource.UserReference> userUsers) {
+            List<SupportTicketApiResource.UserReference> userUsers, List<SupportTicketApiResource.EventEntry> events) {
     }
 }

--- a/src/backend/main/java/ai/mnemosyne_systems/service/EventService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/EventService.java
@@ -1,0 +1,127 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+package ai.mnemosyne_systems.service;
+
+import ai.mnemosyne_systems.model.Ticket;
+import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.Message;
+import ai.mnemosyne_systems.model.event.Event;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class EventService {
+
+    public void saveTicketEvent(Ticket ticket, User createdBy) {
+        if (ticket == null || ticket.id == null) {
+            return;
+        }
+        if (Event.count("key = ?1 and eventType = ?2", ticket.id, EventConstants.TICKET_OPENED) == 0) {
+            record(ticket.id, EventConstants.TICKET_OPENED, ticket.company == null ? null : ticket.company.id,
+                    createdBy == null ? null : createdBy.id, "Ticket opened");
+        }
+        if (ticket.status != null) {
+            handleActionEvent(ticket, createdBy);
+        }
+        if (ticket.category != null && ticket.category.name != null) {
+            handleCategoryEvent(ticket, createdBy);
+        }
+    }
+
+    public List<Event> getAllChangesToEntity(Long entityId) {
+        return getAllChangesToKey(entityId);
+    }
+
+    public List<Event> getAllChangesToKey(Long key) {
+        return Event.find("key = :key", Sort.by("createdAt").ascending(), Map.of("key", key)).list();
+    }
+
+    public void recordMessageCreated(Message message) {
+        if (message == null || message.id == null) {
+            return;
+        }
+        Long companyId = message.ticket == null || message.ticket.company == null ? null : message.ticket.company.id;
+        record(message.id, EventConstants.MESSAGE_CREATED, companyId, message.author == null ? null : message.author.id,
+                "Comment created");
+    }
+
+    public void recordTicketUserAssociation(Ticket ticket, User actor, User member, long eventType) {
+        if (ticket == null || ticket.id == null) {
+            return;
+        }
+        String memberName = member == null || member.fullName == null || member.fullName.isBlank() ? "User"
+                : member.fullName;
+        record(ticket.id, eventType, ticket.company == null ? null : ticket.company.id, actor == null ? null : actor.id,
+                memberName);
+    }
+
+    public void record(Long key, Long eventType, Long companyId, Long userId, String eventValue) {
+        saveEvent(key, eventType, eventValue, companyId, userId);
+    }
+
+    private void handleActionEvent(Ticket ticket, User createdBy) {
+        Event lastActionEvent = Event.find("key = :key AND eventType = :type", Sort.by("createdAt").descending(),
+                Map.of("key", ticket.id, "type", EventConstants.TICKET_STATUS_CHANGED)).firstResult();
+
+        boolean hasChanged = lastActionEvent == null || !ticket.status.toUpperCase().equals(lastActionEvent.eventValue);
+
+        if (hasChanged) {
+            saveEvent(ticket.id, EventConstants.TICKET_STATUS_CHANGED, ticket.status.toUpperCase(),
+                    ticket.company == null ? null : ticket.company.id, createdBy == null ? null : createdBy.id);
+            recordTicketStatusEvent(ticket, createdBy);
+        }
+    }
+
+    private void handleCategoryEvent(Ticket ticket, User createdBy) {
+        Event lastCategoryEvent = Event.find("key = :key AND eventType = :type", Sort.by("createdAt").descending(),
+                Map.of("key", ticket.id, "type", EventConstants.TICKET_CATEGORY_CHANGED)).firstResult();
+
+        boolean hasChanged = lastCategoryEvent == null
+                || !ticket.category.name.toUpperCase().equals(lastCategoryEvent.eventValue);
+
+        if (hasChanged) {
+            saveEvent(ticket.id, EventConstants.TICKET_CATEGORY_CHANGED, ticket.category.name.toUpperCase(),
+                    ticket.company == null ? null : ticket.company.id, createdBy == null ? null : createdBy.id);
+        }
+    }
+
+    public void recordTicketDeleted(Ticket ticket, User deletedBy) {
+        if (ticket != null) {
+            record(ticket.id, EventConstants.TICKET_DELETED, ticket.company == null ? null : ticket.company.id,
+                    deletedBy == null ? null : deletedBy.id, "Ticket deleted");
+        }
+    }
+
+    private void recordTicketStatusEvent(Ticket ticket, User actor) {
+        String status = ticket.status == null ? "" : ticket.status.trim();
+        long eventType = switch (status.toLowerCase()) {
+            case "assigned" -> EventConstants.TICKET_ASSIGNED;
+            case "resolved" -> EventConstants.TICKET_RESOLVED;
+            case "closed" -> EventConstants.TICKET_CLOSED;
+            default -> -1L;
+        };
+        if (eventType != -1L) {
+            record(ticket.id, eventType, ticket.company == null ? null : ticket.company.id,
+                    actor == null ? null : actor.id, "Ticket " + status.toLowerCase());
+        }
+    }
+
+    private void saveEvent(Long key, Long eventType, String eventValue, Long companyId, Long userId) {
+        Event event = new Event();
+        event.key = key;
+        event.eventType = eventType;
+        event.eventValue = eventValue;
+        event.companyId = companyId;
+        event.userId = userId;
+        event.persist();
+    }
+}

--- a/src/backend/main/java/ai/mnemosyne_systems/service/IncomingEmailService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/IncomingEmailService.java
@@ -21,7 +21,6 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +36,9 @@ public class IncomingEmailService {
 
     @Inject
     TicketEmailService ticketEmailService;
+
+    @Inject
+    EventService eventService;
 
     @Transactional
     public IncomingEmailResult processIncomingEmail(String from, String subject, String body,
@@ -79,6 +81,7 @@ public class IncomingEmailService {
         message.author = sender;
         AttachmentHelper.attachToMessage(message, attachments);
         message.persistAndFlush();
+        eventService.recordMessageCreated(message);
         AttachmentHelper.resolveInlineAttachmentUrls(message, attachments);
         ticketEmailService.notifyMessageChange(ticket, message, sender);
         return IncomingEmailResult.processed(ticket.name);
@@ -125,6 +128,7 @@ public class IncomingEmailService {
         ticket.companyEntitlement = entitlement;
         ticket.category = Category.findDefault();
         ticket.persist();
+        eventService.saveTicketEvent(ticket, sender);
         assignCompanyTams(ticket);
         return ticket;
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/service/TicketCreationService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/TicketCreationService.java
@@ -16,6 +16,7 @@ import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +24,9 @@ import java.util.Set;
 
 @ApplicationScoped
 public class TicketCreationService {
+
+    @Inject
+    EventService eventService;
 
     public Ticket createTicketWithInitialMessage(TicketCreationRequest request) {
         Ticket ticket = new Ticket();
@@ -36,6 +40,7 @@ public class TicketCreationService {
         ticket.category = request.category() == null ? Category.findDefault() : request.category();
         ticket.externalIssueLink = trimOrNull(request.externalIssueLink());
         ticket.persist();
+        eventService.saveTicketEvent(ticket, request.requester());
         assignCompanyTams(ticket);
 
         Message message = new Message();
@@ -45,6 +50,8 @@ public class TicketCreationService {
         message.author = request.requester();
         message.isPublic = request.initialMessagePublic();
         message.persist();
+        // Message ids are available after persist for sequence-backed entities.
+        eventService.recordMessageCreated(message);
         return ticket;
     }
 

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -41,6 +41,7 @@ import type {
   SupportTicketDetailRecord,
   VersionInfo,
   ArticleReferenceEntry,
+  EventEntry,
 } from "../types/domain";
 import type { SupportTicketDetailState } from "../types/forms";
 import { Button } from "../components/ui/button";
@@ -277,6 +278,69 @@ function TicketMessageCard({
   );
 }
 
+function ActivityTimeline({ events }: { events: EventEntry[] }) {
+  if (!events || events.length === 0) {
+    return (
+      <div className="space-y-4 pt-4">
+        <h2 className="px-1 text-3xl font-bold tracking-tight">
+          Activity Timeline
+        </h2>
+        <div className="relative border-l-2 border-border/60 ml-4 pl-6 space-y-8 py-2">
+          No events yet
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-4 pt-4">
+      <h2 className="px-1 text-3xl font-bold tracking-tight">
+        Activity Timeline
+      </h2>
+      <div className="relative border-l-2 border-border/60 ml-4 pl-6 space-y-8 py-2">
+        {events.map((event) => {
+          const authorLabel =
+            event.user?.displayName ||
+            event.user?.username ||
+            event.user?.fullName ||
+            "System";
+          return (
+            <div key={event.id} className="relative">
+              <div className="absolute -left-[33px] top-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-muted-foreground/30 bg-background text-muted-foreground">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+              </div>
+              <div className="text-sm text-muted-foreground mb-1">
+                {event.dateLabel || "-"}
+              </div>
+              <div className="text-sm rounded-md border border-border/40 bg-card/50 p-3 shadow-sm inline-block">
+                <span className="font-semibold text-foreground">
+                  {authorLabel}
+                </span>{" "}
+                <span className="text-muted-foreground">triggered action:</span>{" "}
+                <span className="font-medium text-foreground lowercase">
+                  {event.action ? event.action.replaceAll("_", " ") : "unknown"}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function SupportTicketDetailPage({
   sessionState,
   apiBase = "/api/support/tickets",
@@ -353,6 +417,8 @@ export default function SupportTicketDetailPage({
   ).sort((left, right) =>
     (left.articleTitle ?? "").localeCompare(right.articleTitle ?? ""),
   );
+
+  const [showEvent, setShowEvents] = useState<boolean>(false);
 
   useEffect(() => {
     if (!ticket) {
@@ -1100,6 +1166,12 @@ export default function SupportTicketDetailPage({
                 </div>
               )}
             </div>
+
+            <Button type="submit" onClick={() => setShowEvents(!showEvent)}>
+              Events
+            </Button>
+            {showEvent && <ActivityTimeline events={ticket.events || []} />}
+
             {!isClosed ? (
               <div className="space-y-4">
                 <div className="flex items-center justify-between gap-4 px-1">

--- a/src/frontend/src/types/domain/tickets.ts
+++ b/src/frontend/src/types/domain/tickets.ts
@@ -96,10 +96,18 @@ export interface TicketWorkbenchBootstrap {
   [key: string]: unknown;
 }
 
+export interface EventEntry {
+  id: number;
+  action: string;
+  dateLabel?: string;
+  user?: UserReference;
+}
+
 export interface SupportTicketDetailRecord extends TicketReference {
   categories?: NamedEntity[];
   versions?: VersionInfo[];
   messages?: MessageReference[];
+  events?: EventEntry[];
 }
 
 export interface CrossReferenceEntry {


### PR DESCRIPTION
## Summary
- replace the ticket-only entity id with a loose bigint event key and reporting indexes
- add ticket lifecycle, comment, association, and domain lifecycle event types
- emit audit events from ticket and administration workflows

## Validation
- `mvn test`