### PR TITLE
[#38] Handle daylight and standard time

### DIFF
--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
@@ -23,6 +23,7 @@ import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
+import ai.mnemosyne_systems.util.TicketTimeSupport;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.inject.Inject;
@@ -451,10 +452,7 @@ public class SuperuserResource {
                     || ticket.companyEntitlement.supportLevel == null) {
                 continue;
             }
-            long minutes = Duration.between(messageDate, now).toMinutes();
-            if (minutes < 0) {
-                minutes = 0;
-            }
+            long minutes = TicketTimeSupport.elapsedMinutes(messageDate, now);
             String color = resolveSlaColor(ticket.companyEntitlement.supportLevel, minutes);
             if (color != null && !color.isBlank()) {
                 slaColors.put(ticket.id, color);

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketViewSupport.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketViewSupport.java
@@ -13,7 +13,7 @@ import ai.mnemosyne_systems.model.Message;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
-import java.time.Duration;
+import ai.mnemosyne_systems.util.TicketTimeSupport;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -147,10 +147,7 @@ final class SupportTicketViewSupport {
                     || ticket.companyEntitlement.supportLevel == null) {
                 continue;
             }
-            long minutes = Duration.between(messageDate, now).toMinutes();
-            if (minutes < 0) {
-                minutes = 0;
-            }
+            long minutes = TicketTimeSupport.elapsedMinutes(messageDate, now);
             String color = resolveSlaColor(ticket.companyEntitlement.supportLevel, minutes);
             if (color != null && !color.isBlank()) {
                 slaColors.put(ticket.id, color);

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -23,6 +23,7 @@ import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AttachmentHelper;
 import ai.mnemosyne_systems.util.AuthHelper;
+import ai.mnemosyne_systems.util.TicketTimeSupport;
 import io.quarkus.hibernate.orm.panache.Panache;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import io.smallrye.common.annotation.Blocking;
@@ -734,10 +735,7 @@ public class UserResource {
                     || ticket.companyEntitlement.supportLevel == null) {
                 continue;
             }
-            long minutes = java.time.Duration.between(messageDate, now).toMinutes();
-            if (minutes < 0) {
-                minutes = 0;
-            }
+            long minutes = TicketTimeSupport.elapsedMinutes(messageDate, now);
             String color = resolveSlaColor(ticket.companyEntitlement.supportLevel, minutes);
             if (color != null && !color.isBlank()) {
                 slaColors.put(ticket.id, color);

--- a/src/backend/main/java/ai/mnemosyne_systems/service/TicketAutoCloseService.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/service/TicketAutoCloseService.java
@@ -26,8 +26,8 @@ public class TicketAutoCloseService {
     @Inject
     TicketEmailService ticketEmailService;
 
-    // Run once a day at 2 AM
-    @Scheduled(cron = "0 0 2 * * ?")
+    // Run once a day at a DST-independent time so auto-close notifications are never skipped or duplicated.
+    @Scheduled(cron = "0 0 2 * * ?", timeZone = "${ticket.scheduler.timezone}")
     @Transactional
     public void autoCloseTickets() {
         int autoCloseDays = resolveAutoCloseDays();

--- a/src/backend/main/java/ai/mnemosyne_systems/util/TicketTimeSupport.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/util/TicketTimeSupport.java
@@ -1,0 +1,39 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/** Calculates elapsed ticket time on the instant timeline across DST changes. */
+public final class TicketTimeSupport {
+
+    private TicketTimeSupport() {
+    }
+
+    public static long elapsedMinutes(LocalDateTime from, LocalDateTime to) {
+        return Math.max(0, minutesBetween(from, to, ZoneId.systemDefault()));
+    }
+
+    static long elapsedMinutes(LocalDateTime from, LocalDateTime to, ZoneId zone) {
+        return Math.max(0, minutesBetween(from, to, zone));
+    }
+
+    public static long minutesBetween(LocalDateTime from, LocalDateTime to) {
+        return minutesBetween(from, to, ZoneId.systemDefault());
+    }
+
+    private static long minutesBetween(LocalDateTime from, LocalDateTime to, ZoneId zone) {
+        if (from == null || to == null) {
+            return 0;
+        }
+        return Duration.between(from.atZone(zone).toInstant(), to.atZone(zone).toInstant()).toMinutes();
+    }
+}

--- a/src/backend/main/resources/application.properties
+++ b/src/backend/main/resources/application.properties
@@ -37,6 +37,7 @@ quarkus.quinoa.package-manager-command.dev=run dev
 %test.quarkus.http.ssl-port=0
 
 ticket.mailer.from=${MAIL_FROM:no-reply@billetsys.local}
+ticket.scheduler.timezone=${TICKET_SCHEDULER_TIMEZONE:UTC}
 quarkus.mailer.mock=${MAIL_MOCK:true}
 %test.quarkus.mailer.mock=true
 ticket.mail.incoming.enabled=${MAIL_INCOMING_ENABLED:true}

--- a/src/backend/test/java/ai/mnemosyne_systems/util/TicketTimeSupportTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/util/TicketTimeSupportTest.java
@@ -1,0 +1,31 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TicketTimeSupportTest {
+
+    private static final ZoneId NEW_YORK = ZoneId.of("America/New_York");
+
+    @Test
+    void calculatesActualElapsedTimeAcrossDaylightSavingTimeStart() {
+        Assertions.assertEquals(60, TicketTimeSupport.elapsedMinutes(LocalDateTime.of(2026, 3, 8, 1, 30),
+                LocalDateTime.of(2026, 3, 8, 3, 30), NEW_YORK));
+    }
+
+    @Test
+    void calculatesActualElapsedTimeAcrossStandardTimeStart() {
+        Assertions.assertEquals(180, TicketTimeSupport.elapsedMinutes(LocalDateTime.of(2026, 11, 1, 0, 30),
+                LocalDateTime.of(2026, 11, 1, 2, 30), NEW_YORK));
+    }
+}


### PR DESCRIPTION
## Summary

- Calculate ticket SLA elapsed time on the instant timeline, preserving correct color transitions across DST changes.
- Schedule auto-close notifications in configurable UTC so daylight/standard transitions cannot skip or duplicate a run.
- Add regression tests for spring-forward and fall-back transitions.
