### PR TITLE
[#156] feat: add user active/inactive toggle

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Jesper Pedersen <jesper.pedersen@mnemosyne-systems.ai>
 Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Hamza Azeem <hamzaalsherif9@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Mohamed Hamed <alkmohamed40@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -11,6 +11,7 @@ Jesper Pedersen <jesper.pedersen@mnemosyne-systems.ai>
 Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Hamza Azeem <hamzaalsherif9@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Mohamed Hamed <alkmohamed40@gmail.com>
 ```
 
 ## Committers

--- a/src/backend/main/java/ai/mnemosyne_systems/model/User.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/model/User.java
@@ -81,6 +81,9 @@ public class User extends PanacheEntityBase {
     @Column(name = "page_size")
     public Integer pageSize;
 
+    @Column(name = "active", nullable = false, columnDefinition = "boolean default true")
+    public boolean active = true;
+
     public static boolean usernameExists(String username) {
         if (username == null || username.isBlank()) {
             return false;

--- a/src/backend/main/java/ai/mnemosyne_systems/model/event/EventConstants.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/model/event/EventConstants.java
@@ -65,4 +65,6 @@ public class EventConstants {
     public static final long USER_DELETED = 131L;
     public static final long VERSION_CREATED = 132L;
     public static final long VERSION_DELETED = 133L;
+    public static final long USER_ACTIVATED = 134L;
+    public static final long USER_DEACTIVATED = 135L;
 }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/AdminUserApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/AdminUserApiResource.java
@@ -12,20 +12,32 @@ import ai.mnemosyne_systems.model.Company;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import ai.mnemosyne_systems.service.EventService;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 @Path("/api/admin/users")
 @Produces(MediaType.APPLICATION_JSON)
 public class AdminUserApiResource {
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Transactional
@@ -117,7 +129,34 @@ public class AdminUserApiResource {
                 UserDirectoryApiModels.typeLabel(user.type), user.country == null ? null : user.country.name,
                 user.timezone == null ? null : user.timezone.name, user.logoBase64, company == null ? null : company.id,
                 company == null ? null : company.name, company == null ? null : "/companies/" + company.id,
-                "/users/" + user.id + "/edit", "/user/" + user.id + "/delete", backPath);
+                "/users/" + user.id + "/edit", "/user/" + user.id + "/delete", backPath, user.active);
+    }
+
+    @POST
+    @Path("/{id}/active")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Transactional
+    public Response setActive(@CookieParam("authUserIdV3") String auth, @PathParam("id") Long id,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("active") Boolean active) {
+        User currentUser = OwnerResource.requireAdmin(auth);
+        if (active == null) {
+            throw new BadRequestException("Active is required");
+        }
+        User user = User.findById(id);
+        if (user == null) {
+            throw new NotFoundException();
+        }
+        if (currentUser.id != null && currentUser.id.equals(user.id)) {
+            throw new BadRequestException("Cannot change your own active status");
+        }
+        user.active = active;
+        user.persist();
+        Company company = Company.<Company> find("select c from Company c join c.users u where u = ?1", user)
+                .firstResult();
+        eventService.record(user.id, active ? EventConstants.USER_ACTIVATED : EventConstants.USER_DEACTIVATED,
+                company == null ? null : company.id, currentUser.id, active ? "User activated" : "User deactivated");
+        String backPath = company != null ? "/users?companyId=" + company.id : "/users";
+        return ReactRedirectSupport.redirect(client, backPath);
     }
 
     private Company selectCompany(List<Company> companies, Long companyId) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/AuthResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/AuthResource.java
@@ -41,6 +41,9 @@ public class AuthResource {
             return seeOther(errorRedirect("Username and password are required")).build();
         }
         User user = User.find("name", username.trim()).firstResult();
+        if (user != null && !user.active) {
+            return seeOther(errorRedirect("Invalid credentials")).build();
+        }
         if (user == null || user.passwordHash == null || !BcryptUtil.matches(password, user.passwordHash)) {
             return seeOther(errorRedirect("Invalid credentials")).build();
         }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserApiResource.java
@@ -133,7 +133,7 @@ public class ExternalUserApiResource {
                 user.email, user.social, user.phoneNumber, user.phoneExtension, user.type, "External",
                 user.country == null ? null : user.country.name, user.timezone == null ? null : user.timezone.name,
                 user.logoBase64, userCompany.id, userCompany.name, null, "/" + role + "/externals/" + user.id + "/edit",
-                "/" + role + "/externals/" + user.id + "/delete", "/" + role + "/externals");
+                "/" + role + "/externals/" + user.id + "/delete", "/" + role + "/externals", user.active);
     }
 
     private User requireRole(String auth, String role) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserResource.java
@@ -95,11 +95,15 @@ public class ExternalUserResource {
             @PathParam("id") Long id, @FormParam("name") String name, @FormParam("fullName") String fullName,
             @FormParam("email") String email, @FormParam("social") String social,
             @FormParam("phoneNumber") String phoneNumber, @FormParam("phoneExtension") String phoneExtension,
-            @FormParam("countryId") Long countryId, @FormParam("timezoneId") Long timezoneId) {
+            @FormParam("countryId") Long countryId, @FormParam("timezoneId") Long timezoneId,
+            @FormParam("active") Boolean active) {
         User currentUser = requireRole(auth, role);
         User user = User.findById(id);
         if (user == null || !User.TYPE_EXTERNAL.equals(user.type)) {
             throw new NotFoundException();
+        }
+        if (active != null && currentUser.id != null && currentUser.id.equals(user.id)) {
+            throw new BadRequestException("Cannot change your own active status");
         }
 
         Company userCompany = Company.<Company> find("select c from Company c join c.users u where u = ?1", user)
@@ -132,7 +136,19 @@ public class ExternalUserResource {
             user.timezone = Timezone.findById(timezoneId);
         }
 
+        boolean activeChanged = active != null && active != user.active;
+        if (active != null) {
+            user.active = active;
+        }
+
         user.persist();
+        if (activeChanged) {
+            eventService.record(user.id,
+                    active ? ai.mnemosyne_systems.model.event.EventConstants.USER_ACTIVATED
+                            : ai.mnemosyne_systems.model.event.EventConstants.USER_DEACTIVATED,
+                    userCompany == null ? null : userCompany.id, currentUser.id,
+                    active ? "User activated" : "User deactivated");
+        }
         return Response.seeOther(URI.create("/" + role + "/externals")).build();
     }
 

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserDirectoryApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserDirectoryApiResource.java
@@ -13,12 +13,20 @@ import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -30,6 +38,9 @@ import java.util.List;
 @Path("/api/superuser")
 @Produces(MediaType.APPLICATION_JSON)
 public class SuperuserDirectoryApiResource {
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("/users")
@@ -133,6 +144,42 @@ public class SuperuserDirectoryApiResource {
                 "/superuser/users?companyId=" + company.id);
     }
 
+    @POST
+    @Path("/users/{id}/active")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Transactional
+    public Response setActive(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("active") Boolean active) {
+        User currentUser = requireSuperuser(auth);
+        if (active == null) {
+            throw new BadRequestException("Active is required");
+        }
+        User user = User.findById(id);
+        if (user == null) {
+            throw new NotFoundException();
+        }
+        if (currentUser.id != null && currentUser.id.equals(user.id)) {
+            throw new BadRequestException("Cannot change your own active status");
+        }
+        if (!User.TYPE_USER.equalsIgnoreCase(user.type) && !User.TYPE_EXTERNAL.equalsIgnoreCase(user.type)) {
+            throw new NotFoundException();
+        }
+        boolean inScope = Company.count(
+                "select count(c) from Company c join c.users current join c.users viewed where current = ?1 and viewed = ?2",
+                currentUser, user) > 0;
+        if (!inScope) {
+            throw new NotFoundException();
+        }
+        user.active = active;
+        user.persist();
+        Company company = Company.<Company> find("select c from Company c join c.users u where u = ?1", user)
+                .firstResult();
+        eventService.record(user.id, active ? EventConstants.USER_ACTIVATED : EventConstants.USER_DEACTIVATED,
+                company == null ? null : company.id, currentUser.id, active ? "User activated" : "User deactivated");
+        String backPath = company != null ? "/superuser/users?companyId=" + company.id : "/superuser/users";
+        return ReactRedirectSupport.redirect(client, backPath);
+    }
+
     private UserDirectoryApiModels.UserDetailResponse detailResponse(User currentUser, User user,
             boolean allowTicketAssignmentAccess) {
         Company company = Company.<Company> find("select c from Company c join c.users u where u = ?1", user)
@@ -153,7 +200,8 @@ public class SuperuserDirectoryApiResource {
                 UserDirectoryApiModels.typeLabel(user.type), user.country == null ? null : user.country.name,
                 user.timezone == null ? null : user.timezone.name, user.logoBase64, company == null ? null : company.id,
                 company == null ? null : company.name, company == null ? null : "/superuser/companies/" + company.id,
-                null, null, company == null ? "/superuser/users" : "/superuser/users?companyId=" + company.id);
+                null, null, company == null ? "/superuser/users" : "/superuser/users?companyId=" + company.id,
+                user.active);
     }
 
     private boolean canViewSupportUser(User currentUser, User supportUser) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserTicketApiResource.java
@@ -254,7 +254,7 @@ public class SuperuserTicketApiResource {
     private SupportTicketApiResource.UserReference toUserReference(User user) {
         return new SupportTicketApiResource.UserReference(user.id, user.name, user.getDisplayName(), user.fullName,
                 user.email, user.type, user.country == null ? null : user.country.name,
-                user.timezone == null ? null : user.timezone.name, user.logoBase64, userPath(user));
+                user.timezone == null ? null : user.timezone.name, user.logoBase64, userPath(user), user.active);
     }
 
     private SupportTicketApiResource.MessageEntry toMessageEntry(Message message,

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportTicketApiResource.java
@@ -281,7 +281,7 @@ public class SupportTicketApiResource {
     private UserReference toUserReference(User user) {
         return new UserReference(user.id, user.name, user.getDisplayName(), user.fullName, user.email, user.type,
                 user.country == null ? null : user.country.name, user.timezone == null ? null : user.timezone.name,
-                user.logoBase64, userPath(user));
+                user.logoBase64, userPath(user), user.active);
     }
 
     private MessageEntry toMessageEntry(Message message, java.util.Map<Long, Ticket> ticketCache) {
@@ -438,7 +438,8 @@ public class SupportTicketApiResource {
     }
 
     public record UserReference(Long id, String username, String displayName, String fullName, String email,
-            String type, String countryName, String timezoneName, String logoBase64, String detailPath) {
+            String type, String countryName, String timezoneName, String logoBase64, String detailPath,
+            boolean active) {
     }
 
     public record MessageEntry(Long id, String body, String dateLabel, String date, UserReference author,

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportUserApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportUserApiResource.java
@@ -12,12 +12,20 @@ import ai.mnemosyne_systems.model.Company;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -29,6 +37,9 @@ import java.util.List;
 @Path("/api/support")
 @Produces(MediaType.APPLICATION_JSON)
 public class SupportUserApiResource {
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("/users")
@@ -139,6 +150,36 @@ public class SupportUserApiResource {
                 "/support/users?companyId=" + company.id);
     }
 
+    @POST
+    @Path("/users/{id}/active")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Transactional
+    public Response setActive(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("active") Boolean active) {
+        User currentUser = requireSupport(auth);
+        if (active == null) {
+            throw new BadRequestException("Active is required");
+        }
+        User user = User.findById(id);
+        if (user == null) {
+            throw new NotFoundException();
+        }
+        if (currentUser.id != null && currentUser.id.equals(user.id)) {
+            throw new BadRequestException("Cannot change your own active status");
+        }
+        if (!User.TYPE_USER.equalsIgnoreCase(user.type) && !User.TYPE_EXTERNAL.equalsIgnoreCase(user.type)) {
+            throw new NotFoundException();
+        }
+        user.active = active;
+        user.persist();
+        Company company = Company.<Company> find("select c from Company c join c.users u where u = ?1", user)
+                .firstResult();
+        eventService.record(user.id, active ? EventConstants.USER_ACTIVATED : EventConstants.USER_DEACTIVATED,
+                company == null ? null : company.id, currentUser.id, active ? "User activated" : "User deactivated");
+        String backPath = company != null ? "/support/users?companyId=" + company.id : "/support/users";
+        return ReactRedirectSupport.redirect(client, backPath);
+    }
+
     private UserDirectoryApiModels.UserDetailResponse profileDetail(Long id, String expectedType, String backPath) {
         User user = User.findById(id);
         if (user == null) {
@@ -154,7 +195,7 @@ public class SupportUserApiResource {
                 UserDirectoryApiModels.typeLabel(user.type), user.country == null ? null : user.country.name,
                 user.timezone == null ? null : user.timezone.name, user.logoBase64, company == null ? null : company.id,
                 company == null ? null : company.name, company == null ? null : "/support/companies/" + company.id,
-                null, null, backPath);
+                null, null, backPath, user.active);
     }
 
     private List<UserDirectoryApiModels.UserReference> usersForCompany(Company company, String type, String basePath) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/TamUserApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/TamUserApiResource.java
@@ -12,13 +12,22 @@ import ai.mnemosyne_systems.model.Company;
 import ai.mnemosyne_systems.model.Country;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.model.event.EventConstants;
+import ai.mnemosyne_systems.service.EventService;
 import ai.mnemosyne_systems.util.AuthHelper;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
@@ -28,6 +37,9 @@ import java.util.List;
 @Path("/api/tam/users")
 @Produces(MediaType.APPLICATION_JSON)
 public class TamUserApiResource {
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Transactional
@@ -81,6 +93,42 @@ public class TamUserApiResource {
                 List.of(new UserDirectoryApiModels.TypeOption(User.TYPE_USER, "User"),
                         new UserDirectoryApiModels.TypeOption(User.TYPE_EXTERNAL, "External")),
                 UserDirectoryApiModels.userFormData(newUser, selectedCompany.id));
+    }
+
+    @POST
+    @Path("/{id}/active")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Transactional
+    public Response setActive(@CookieParam(AuthHelper.AUTH_COOKIE) String auth, @PathParam("id") Long id,
+            @HeaderParam("X-Billetsys-Client") String client, @FormParam("active") Boolean active) {
+        User currentUser = requireTam(auth);
+        if (active == null) {
+            throw new BadRequestException("Active is required");
+        }
+        User user = User.findById(id);
+        if (user == null) {
+            throw new NotFoundException();
+        }
+        if (currentUser.id != null && currentUser.id.equals(user.id)) {
+            throw new BadRequestException("Cannot change your own active status");
+        }
+        if (!User.TYPE_USER.equalsIgnoreCase(user.type) && !User.TYPE_EXTERNAL.equalsIgnoreCase(user.type)) {
+            throw new NotFoundException();
+        }
+        boolean inScope = Company.count(
+                "select count(c) from Company c join c.users current join c.users viewed where current = ?1 and viewed = ?2",
+                currentUser, user) > 0;
+        if (!inScope) {
+            throw new NotFoundException();
+        }
+        user.active = active;
+        user.persist();
+        Company company = Company.<Company> find("select c from Company c join c.users u where u = ?1", user)
+                .firstResult();
+        eventService.record(user.id, active ? EventConstants.USER_ACTIVATED : EventConstants.USER_DEACTIVATED,
+                company == null ? null : company.id, currentUser.id, active ? "User activated" : "User deactivated");
+        String backPath = company != null ? "/tam/users?companyId=" + company.id : "/tam/users";
+        return ReactRedirectSupport.redirect(client, backPath);
     }
 
     private Company selectCompany(List<Company> companies, Long companyId) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserDirectoryApiModels.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserDirectoryApiModels.java
@@ -34,7 +34,7 @@ public final class UserDirectoryApiModels {
     }
 
     public record UserReference(Long id, String username, String displayName, String email, String type,
-            String typeLabel, String detailPath, String editPath) {
+            String typeLabel, String detailPath, String editPath, boolean active) {
     }
 
     public record DirectoryListResponse(String title, String description, Long selectedCompanyId,
@@ -43,7 +43,7 @@ public final class UserDirectoryApiModels {
     }
 
     public record UserFormData(Long id, String name, String fullName, String email, String social, String phoneNumber,
-            String phoneExtension, Long countryId, Long timezoneId, String type, Long companyId) {
+            String phoneExtension, Long countryId, Long timezoneId, String type, Long companyId, Boolean active) {
     }
 
     public record UserFormResponse(String title, String submitPath, String cancelPath, Long selectedCompanyId,
@@ -54,7 +54,7 @@ public final class UserDirectoryApiModels {
     public record UserDetailResponse(Long id, String username, String displayName, String fullName, String email,
             String social, String phoneNumber, String phoneExtension, String type, String typeLabel, String countryName,
             String timezoneName, String logoBase64, Long companyId, String companyName, String companyPath,
-            String editPath, String deletePath, String backPath) {
+            String editPath, String deletePath, String backPath, boolean active) {
     }
 
     public record CompanyDetailResponse(Long id, String name, String address1, String address2, String city,
@@ -88,7 +88,8 @@ public final class UserDirectoryApiModels {
     public static UserReference userReference(User user, String detailPath, String editPath) {
         return new UserReference(user == null ? null : user.id, user == null ? null : user.name,
                 user == null ? null : user.getDisplayName(), user == null ? null : user.email,
-                user == null ? null : user.type, typeLabel(user == null ? null : user.type), detailPath, editPath);
+                user == null ? null : user.type, typeLabel(user == null ? null : user.type), detailPath, editPath,
+                user != null && user.active);
     }
 
     public static UserFormData userFormData(User user, Long companyId) {
@@ -98,7 +99,7 @@ public final class UserDirectoryApiModels {
                 user == null ? null : user.phoneExtension,
                 user == null || user.country == null ? null : user.country.id,
                 user == null || user.timezone == null ? null : user.timezone.id, user == null ? null : user.type,
-                companyId);
+                companyId, user == null ? null : user.active);
     }
 
     public static String typeLabel(String type) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -529,11 +529,15 @@ public class UserResource {
             @FormParam("social") String social, @FormParam("phoneNumber") String phoneNumber,
             @FormParam("phoneExtension") String phoneExtension, @FormParam("timezoneId") Long timezoneId,
             @FormParam("countryId") Long countryId, @FormParam("type") String type,
-            @FormParam("password") String password, @FormParam("companyId") Long companyId) {
-        requireAdmin(auth);
+            @FormParam("password") String password, @FormParam("companyId") Long companyId,
+            @FormParam("active") Boolean active) {
+        User currentUser = requireAdmin(auth);
         User editUser = User.findById(id);
         if (editUser == null) {
             throw new NotFoundException();
+        }
+        if (active != null && currentUser.id != null && currentUser.id.equals(editUser.id)) {
+            throw new BadRequestException("Cannot change your own active status");
         }
         validateUserFields(name, email, type, false, password, editUser.name);
         if (editUser.name == null || editUser.name.isBlank()) {
@@ -552,6 +556,10 @@ public class UserResource {
         if (password != null && !password.isBlank()) {
             editUser.passwordHash = BcryptUtil.bcryptHash(password);
         }
+        boolean activeChanged = active != null && active != editUser.active;
+        if (active != null) {
+            editUser.active = active;
+        }
         List<Company> currentCompanies = Company.find("select c from Company c join c.users u where u = ?1", editUser)
                 .list();
         for (Company c : currentCompanies) {
@@ -562,6 +570,16 @@ public class UserResource {
             if (company != null) {
                 company.users.add(editUser);
             }
+        }
+        if (activeChanged) {
+            Company company = companyId != null ? Company.findById(companyId)
+                    : Company.<Company> find("select c from Company c join c.users u where u = ?1", editUser)
+                            .firstResult();
+            eventService.record(editUser.id,
+                    active ? ai.mnemosyne_systems.model.event.EventConstants.USER_ACTIVATED
+                            : ai.mnemosyne_systems.model.event.EventConstants.USER_DEACTIVATED,
+                    company == null ? null : company.id, currentUser.id,
+                    active ? "User activated" : "User deactivated");
         }
         return ReactRedirectSupport.redirect(client, "/users");
     }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserTicketApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserTicketApiResource.java
@@ -262,7 +262,7 @@ public class UserTicketApiResource {
     private SupportTicketApiResource.UserReference toUserReference(User user) {
         return new SupportTicketApiResource.UserReference(user.id, user.name, user.getDisplayName(), user.fullName,
                 user.email, user.type, user.country == null ? null : user.country.name,
-                user.timezone == null ? null : user.timezone.name, user.logoBase64, userPath(user));
+                user.timezone == null ? null : user.timezone.name, user.logoBase64, userPath(user), user.active);
     }
 
     private SupportTicketApiResource.MessageEntry toMessageEntry(Message message,

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserViewApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserViewApiResource.java
@@ -112,7 +112,7 @@ public class UserViewApiResource {
                 UserDirectoryApiModels.typeLabel(user.type), user.country == null ? null : user.country.name,
                 user.timezone == null ? null : user.timezone.name, user.logoBase64, company == null ? null : company.id,
                 company == null ? null : company.name, company == null ? null : "/user/companies/" + company.id, null,
-                null, "/user/tickets");
+                null, "/user/tickets", user.active);
     }
 
     private List<UserDirectoryApiModels.UserReference> usersForCompany(Company company, String type, String basePath) {

--- a/src/backend/main/java/ai/mnemosyne_systems/util/AuthHelper.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/util/AuthHelper.java
@@ -40,7 +40,7 @@ public final class AuthHelper {
         }
         activeSession.lastActivityAt = now;
         User user = User.findById(sessionCookie.userId());
-        if (user == null) {
+        if (user == null || !user.active) {
             ACTIVE_TOKENS.remove(sessionCookie.userId(), activeSession);
             return null;
         }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/AccessTestSupport.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/AccessTestSupport.java
@@ -76,6 +76,13 @@ abstract class AccessTestSupport {
     }
 
     @Transactional
+    void setUserActive(String email, boolean active) {
+        User user = User.find("email", email).firstResult();
+        Assertions.assertNotNull(user);
+        user.active = active;
+    }
+
+    @Transactional
     void setUserEmailFormat(String email, String emailFormat) {
         User user = User.find("email", email).firstResult();
         Assertions.assertNotNull(user);

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/AdminAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/AdminAccessTest.java
@@ -22,6 +22,8 @@ import ai.mnemosyne_systems.model.Ticket;
 import ai.mnemosyne_systems.model.Timezone;
 import ai.mnemosyne_systems.model.User;
 import ai.mnemosyne_systems.model.Version;
+import ai.mnemosyne_systems.model.event.Event;
+import ai.mnemosyne_systems.model.event.EventConstants;
 import ai.mnemosyne_systems.service.MailboxPollingService;
 import ai.mnemosyne_systems.service.TicketEmailService;
 import ai.mnemosyne_systems.util.AuthHelper;
@@ -527,6 +529,132 @@ class AdminAccessTest extends AccessTestSupport {
         Assertions.assertNull(refreshedUser(targetUserId));
         Assertions.assertFalse(companyHasUser(companyId, "delete-target-2@mnemosyne-systems.ai"));
         Assertions.assertTrue(deleteReferencesCleared("delete-target-2@mnemosyne-systems.ai"));
+    }
+
+    @Test
+    void adminCanToggleUserActiveStatus() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        ensureUser("toggle-target", "toggle-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        setUserActive("toggle-target@mnemosyne-systems.ai", true);
+        String cookie = login("admin", "admin");
+        User target = User.find("email", "toggle-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/admin/users/" + target.id + "/active").then().statusCode(303);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/admin/users/" + target.id).then()
+                .statusCode(200).body("active", Matchers.equalTo(false));
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/admin/users/" + target.id + "/active").then().statusCode(303);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/admin/users/" + target.id).then()
+                .statusCode(200).body("active", Matchers.equalTo(true));
+    }
+
+    @Test
+    void adminToggleLogsDedicatedActivationEvents() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        ensureUser("event-toggle-target", "event-toggle-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        setUserActive("event-toggle-target@mnemosyne-systems.ai", true);
+        String cookie = login("admin", "admin");
+        User target = User.find("email", "event-toggle-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/admin/users/" + target.id + "/active").then().statusCode(303);
+
+        Assertions.assertEquals(1,
+                Event.count("key = ?1 and eventType = ?2", target.id, EventConstants.USER_DEACTIVATED));
+        Assertions.assertEquals(0, Event.count("key = ?1 and eventType = ?2", target.id, EventConstants.USER_DELETED));
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/admin/users/" + target.id + "/active").then().statusCode(303);
+
+        Assertions.assertEquals(1,
+                Event.count("key = ?1 and eventType = ?2", target.id, EventConstants.USER_ACTIVATED));
+        Assertions.assertEquals(0, Event.count("key = ?1 and eventType = ?2", target.id, EventConstants.USER_CREATED));
+    }
+
+    @Test
+    void adminCannotToggleOwnActiveStatus() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        String cookie = login("admin", "admin");
+        User admin = User.find("email", "admin@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(admin);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/admin/users/" + admin.id + "/active").then().statusCode(400);
+        Assertions.assertTrue(refreshedUser(admin.id).active);
+    }
+
+    @Test
+    void adminToggleRequiresActiveParam() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        ensureUser("toggle-param-target", "toggle-param-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        setUserActive("toggle-param-target@mnemosyne-systems.ai", true);
+        String cookie = login("admin", "admin");
+        User target = User.find("email", "toggle-param-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).post("/api/admin/users/" + target.id + "/active").then()
+                .statusCode(400);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void adminCanToggleAnyUserType() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        ensureUser("toggle-support", "toggle-support@mnemosyne-systems.ai", User.TYPE_SUPPORT, "password");
+        setUserActive("toggle-support@mnemosyne-systems.ai", true);
+        String cookie = login("admin", "admin");
+        User target = User.find("email", "toggle-support@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/admin/users/" + target.id + "/active").then().statusCode(303);
+        Assertions.assertFalse(refreshedUser(target.id).active);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/admin/users/" + target.id + "/active").then().statusCode(303);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void adminCanUpdateActiveStatusViaUserForm() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        ensureUser("form-toggle-target", "form-toggle-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        setUserActive("form-toggle-target@mnemosyne-systems.ai", true);
+        String cookie = login("admin", "admin");
+        User target = User.find("email", "form-toggle-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+        User admin = User.find("email", "admin@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(admin);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("name", "form-toggle-target")
+                .formParam("email", "form-toggle-target@mnemosyne-systems.ai").formParam("type", User.TYPE_USER)
+                .formParam("active", "false").post("/user/" + target.id).then().statusCode(303);
+        Assertions.assertFalse(refreshedUser(target.id).active);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("name", "form-toggle-target")
+                .formParam("email", "form-toggle-target@mnemosyne-systems.ai").formParam("type", User.TYPE_USER)
+                .formParam("active", "true").post("/user/" + target.id).then().statusCode(303);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("name", "admin")
+                .formParam("email", "admin@mnemosyne-systems.ai").formParam("type", User.TYPE_ADMIN)
+                .formParam("active", "false").post("/user/" + admin.id).then().statusCode(400);
+        Assertions.assertTrue(refreshedUser(admin.id).active);
     }
 
     @Transactional

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/SuperuserAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/SuperuserAccessTest.java
@@ -234,4 +234,96 @@ class SuperuserAccessTest extends AccessTestSupport {
                 .statusCode(200).body("redirectTo", Matchers.equalTo("/superuser/tickets/" + createdTicketId));
     }
 
+    @Test
+    void superuserCanToggleCompanyUserActiveStatus() {
+        ensureUser("superuser1", "superuser1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser1");
+        ensureUser("su-toggle-target", "su-toggle-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        Long companyId = ensureCompany("Superuser Toggle Co");
+        ensureCompanyUsers(companyId, "superuser1@mnemosyne-systems.ai", "su-toggle-target@mnemosyne-systems.ai");
+        setUserActive("su-toggle-target@mnemosyne-systems.ai", true);
+        String cookie = login("superuser1", "superuser1");
+        User target = User.find("email", "su-toggle-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/superuser/users/" + target.id + "/active").then().statusCode(303);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/superuser/user-profiles/" + target.id)
+                .then().statusCode(200).body("active", Matchers.equalTo(false));
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/superuser/users/" + target.id + "/active").then().statusCode(303);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/superuser/user-profiles/" + target.id)
+                .then().statusCode(200).body("active", Matchers.equalTo(true));
+    }
+
+    @Test
+    void superuserCannotToggleOwnActiveStatus() {
+        ensureUser("superuser1", "superuser1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser1");
+        Long companyId = ensureCompany("Superuser Toggle Co");
+        ensureCompanyUsers(companyId, "superuser1@mnemosyne-systems.ai");
+        String cookie = login("superuser1", "superuser1");
+        User superuser = User.find("email", "superuser1@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(superuser);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/superuser/users/" + superuser.id + "/active").then().statusCode(400);
+        Assertions.assertTrue(refreshedUser(superuser.id).active);
+    }
+
+    @Test
+    void superuserCannotTogglePrivilegedAccount() {
+        ensureUser("superuser1", "superuser1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser1");
+        ensureUser("su-priv-peer", "su-priv-peer@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser-priv");
+        Long companyId = ensureCompany("Superuser Toggle Co");
+        ensureCompanyUsers(companyId, "superuser1@mnemosyne-systems.ai", "su-priv-peer@mnemosyne-systems.ai");
+        setUserActive("su-priv-peer@mnemosyne-systems.ai", true);
+        String cookie = login("superuser1", "superuser1");
+        User target = User.find("email", "su-priv-peer@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/superuser/users/" + target.id + "/active").then().statusCode(404);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void superuserCannotToggleUserOutsideOwnCompany() {
+        ensureUser("superuser1", "superuser1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser1");
+        ensureUser("su-outsider", "su-outsider@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        Long companyId = ensureCompany("Superuser Toggle Co");
+        ensureCompanyUsers(companyId, "superuser1@mnemosyne-systems.ai");
+        Long otherCompanyId = ensureCompany("Superuser Other Co");
+        ensureCompanyUsers(otherCompanyId, "su-outsider@mnemosyne-systems.ai");
+        setUserActive("su-outsider@mnemosyne-systems.ai", true);
+        String cookie = login("superuser1", "superuser1");
+        User target = User.find("email", "su-outsider@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/superuser/users/" + target.id + "/active").then().statusCode(404);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void superuserToggleRequiresActiveParam() {
+        ensureUser("superuser1", "superuser1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "superuser1");
+        ensureUser("su-param-target", "su-param-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        Long companyId = ensureCompany("Superuser Toggle Co");
+        ensureCompanyUsers(companyId, "superuser1@mnemosyne-systems.ai", "su-param-target@mnemosyne-systems.ai");
+        setUserActive("su-param-target@mnemosyne-systems.ai", true);
+        String cookie = login("superuser1", "superuser1");
+        User target = User.find("email", "su-param-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).post("/api/superuser/users/" + target.id + "/active").then()
+                .statusCode(400);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
 }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/SupportAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/SupportAccessTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Properties;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -938,6 +939,100 @@ class SupportAccessTest extends AccessTestSupport {
         RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).header("X-Billetsys-Client", "react")
                 .post("/support/tickets/" + createdTicket.id + "/assign").then().statusCode(200)
                 .body("redirectTo", Matchers.equalTo("/support/tickets/" + createdTicket.id));
+    }
+
+    @Test
+    void supportCanToggleUserActiveStatus() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        ensureUser("support-toggle-target", "support-toggle-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        setUserActive("support-toggle-target@mnemosyne-systems.ai", true);
+        String cookie = login("support1", "support1");
+        User target = User.find("email", "support-toggle-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/support/users/" + target.id + "/active").then().statusCode(303);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/support/user-profiles/" + target.id).then()
+                .statusCode(200).body("active", Matchers.equalTo(false));
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/support/users/" + target.id + "/active").then().statusCode(303);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/support/user-profiles/" + target.id).then()
+                .statusCode(200).body("active", Matchers.equalTo(true));
+    }
+
+    @Test
+    void supportCannotToggleOwnActiveStatus() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        String cookie = login("support1", "support1");
+        User support = User.find("email", "support1@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(support);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/support/users/" + support.id + "/active").then().statusCode(400);
+        Assertions.assertTrue(refreshedUser(support.id).active);
+    }
+
+    @Test
+    void supportCannotTogglePrivilegedAccount() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        ensureUser("support-priv-target", "support-priv-target@mnemosyne-systems.ai", User.TYPE_ADMIN, "password");
+        setUserActive("support-priv-target@mnemosyne-systems.ai", true);
+        String cookie = login("support1", "support1");
+        User target = User.find("email", "support-priv-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/support/users/" + target.id + "/active").then().statusCode(404);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void supportToggleRequiresActiveParam() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        ensureUser("support-param-target", "support-param-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        setUserActive("support-param-target@mnemosyne-systems.ai", true);
+        String cookie = login("support1", "support1");
+        User target = User.find("email", "support-param-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).post("/api/support/users/" + target.id + "/active").then()
+                .statusCode(400);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    @Disabled("Pre-existing bug: ExternalUserResource POST endpoints are unroutable (always 404), unrelated to #156. Predates this PR — introduced in d3ee2ea (#136).")
+    void supportCanUpdateExternalUserActiveStatus() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        ensureUser("support-ext-target", "support-ext-target@mnemosyne-systems.ai", User.TYPE_EXTERNAL, "password");
+        Long companyId = ensureCompany("Support External Active Co");
+        ensureCompanyUsers(companyId, "support1@mnemosyne-systems.ai", "support-ext-target@mnemosyne-systems.ai");
+        setUserActive("support-ext-target@mnemosyne-systems.ai", true);
+        String cookie = login("support1", "support1");
+        User target = User.find("email", "support-ext-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/support/externals/" + target.id).then()
+                .statusCode(200).body("active", Matchers.equalTo(true));
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "External Target")
+                .formParam("email", "support-ext-target@mnemosyne-systems.ai").formParam("active", "false")
+                .post("/support/externals/" + target.id).then().statusCode(303);
+        Assertions.assertFalse(refreshedUser(target.id).active);
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/support/externals/" + target.id).then()
+                .statusCode(200).body("active", Matchers.equalTo(false));
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "External Target")
+                .formParam("email", "support-ext-target@mnemosyne-systems.ai").formParam("active", "true")
+                .post("/support/externals/" + target.id).then().statusCode(303);
+        Assertions.assertTrue(refreshedUser(target.id).active);
     }
 
 }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/TAMAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/TAMAccessTest.java
@@ -183,4 +183,93 @@ class TAMAccessTest extends AccessTestSupport {
                 .then().statusCode(303);
     }
 
+    @Test
+    void tamCanToggleAssignedUserActiveStatus() {
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        ensureUser("tam-toggle-target", "tam-toggle-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        Long companyId = ensureCompany("TAM Toggle Co");
+        ensureCompanyUsers(companyId, "tam1@mnemosyne-systems.ai", "tam-toggle-target@mnemosyne-systems.ai");
+        setUserActive("tam-toggle-target@mnemosyne-systems.ai", true);
+        String cookie = login("tam1", "tam1");
+        User target = User.find("email", "tam-toggle-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/tam/users/" + target.id + "/active").then().statusCode(303);
+        Assertions.assertFalse(refreshedUser(target.id).active);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/tam/users/" + target.id + "/active").then().statusCode(303);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void tamCannotToggleOwnActiveStatus() {
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        Long companyId = ensureCompany("TAM Toggle Co");
+        ensureCompanyUsers(companyId, "tam1@mnemosyne-systems.ai");
+        String cookie = login("tam1", "tam1");
+        User tam = User.find("email", "tam1@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(tam);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/tam/users/" + tam.id + "/active").then().statusCode(400);
+        Assertions.assertTrue(refreshedUser(tam.id).active);
+    }
+
+    @Test
+    void tamCannotTogglePrivilegedAccount() {
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        ensureUser("tam-priv-peer", "tam-priv-peer@mnemosyne-systems.ai", User.TYPE_TAM, "password");
+        Long companyId = ensureCompany("TAM Toggle Co");
+        ensureCompanyUsers(companyId, "tam1@mnemosyne-systems.ai", "tam-priv-peer@mnemosyne-systems.ai");
+        setUserActive("tam-priv-peer@mnemosyne-systems.ai", true);
+        String cookie = login("tam1", "tam1");
+        User target = User.find("email", "tam-priv-peer@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/tam/users/" + target.id + "/active").then().statusCode(404);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void tamCannotToggleUserOutsideAssignedCompany() {
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        ensureUser("tam-outsider", "tam-outsider@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        Long companyId = ensureCompany("TAM Toggle Co");
+        ensureCompanyUsers(companyId, "tam1@mnemosyne-systems.ai");
+        Long otherCompanyId = ensureCompany("TAM Other Co");
+        ensureCompanyUsers(otherCompanyId, "tam-outsider@mnemosyne-systems.ai");
+        setUserActive("tam-outsider@mnemosyne-systems.ai", true);
+        String cookie = login("tam1", "tam1");
+        User target = User.find("email", "tam-outsider@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/tam/users/" + target.id + "/active").then().statusCode(404);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
+    @Test
+    void tamToggleRequiresActiveParam() {
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        ensureUser("tam-param-target", "tam-param-target@mnemosyne-systems.ai", User.TYPE_USER, "password");
+        Long companyId = ensureCompany("TAM Toggle Co");
+        ensureCompanyUsers(companyId, "tam1@mnemosyne-systems.ai", "tam-param-target@mnemosyne-systems.ai");
+        setUserActive("tam-param-target@mnemosyne-systems.ai", true);
+        String cookie = login("tam1", "tam1");
+        User target = User.find("email", "tam-param-target@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(target);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).post("/api/tam/users/" + target.id + "/active").then().statusCode(400);
+        Assertions.assertTrue(refreshedUser(target.id).active);
+    }
+
 }

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/UserAccessTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/UserAccessTest.java
@@ -206,6 +206,48 @@ class UserAccessTest extends AccessTestSupport {
     }
 
     @Test
+    void inactiveUserCannotLogin() {
+        ensureUser("inactive-login-user", "inactive-login-user@mnemosyne-systems.ai", User.TYPE_USER, "secret");
+        ensureUser("login-compare-user", "login-compare-user@mnemosyne-systems.ai", User.TYPE_USER, "secret");
+        setUserActive("inactive-login-user@mnemosyne-systems.ai", false);
+
+        String inactiveLocation = RestAssured.given().redirects().follow(false).contentType(ContentType.URLENC)
+                .formParam("username", "inactive-login-user").formParam("password", "secret").post("/login").then()
+                .statusCode(303).extract().header("Location");
+        String wrongPasswordLocation = RestAssured.given().redirects().follow(false).contentType(ContentType.URLENC)
+                .formParam("username", "login-compare-user").formParam("password", "wrong").post("/login").then()
+                .statusCode(303).extract().header("Location");
+        Assertions.assertEquals(wrongPasswordLocation, inactiveLocation);
+        Assertions.assertTrue(inactiveLocation.contains("Invalid"));
+
+        setUserActive("inactive-login-user@mnemosyne-systems.ai", true);
+    }
+
+    @Test
+    void deactivatedSessionIsInvalidated() {
+        ensureUser("admin", "admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin");
+        ensureUser("session-victim", "session-victim@mnemosyne-systems.ai", User.TYPE_SUPPORT, "secret");
+        setUserActive("session-victim@mnemosyne-systems.ai", true);
+        String adminCookie = login("admin", "admin");
+        String victimCookie = login("session-victim", "secret");
+        User victim = User.find("email", "session-victim@mnemosyne-systems.ai").firstResult();
+        Assertions.assertNotNull(victim);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, victimCookie).get("/api/articles").then().statusCode(200);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, adminCookie)
+                .contentType(ContentType.URLENC).formParam("active", "false")
+                .post("/api/admin/users/" + victim.id + "/active").then().statusCode(303);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, victimCookie).get("/api/articles").then().statusCode(401);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, adminCookie)
+                .contentType(ContentType.URLENC).formParam("active", "true")
+                .post("/api/admin/users/" + victim.id + "/active").then().statusCode(303);
+        Assertions.assertTrue(refreshedUser(victim.id).active);
+    }
+
+    @Test
     void reactLoginRedirectsUsersToUserTickets() {
         ensureUser("user", "user@mnemosyne-systems.ai", User.TYPE_USER, "user");
 

--- a/src/frontend/src/components/users/UserComponents.tsx
+++ b/src/frontend/src/components/users/UserComponents.tsx
@@ -35,6 +35,19 @@ interface SelectableUsersProps {
   selectionMode?: "multiple" | "single";
 }
 
+export function isInactive(user: UserReference): boolean {
+  return user.active === false;
+}
+
+export function InactiveIcon() {
+  return (
+    <i
+      className="ti ti-badge-off ml-1 text-muted-foreground"
+      title="Inactive user"
+    />
+  );
+}
+
 export function UserRoleBadge({
   type,
   className = "",
@@ -84,6 +97,16 @@ export function UserHoverLink({
   const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
 
   if (!user?.detailPath) {
+    if (user && isInactive(user)) {
+      return (
+        <span className="inline-flex items-center gap-1 align-bottom">
+          <span className="line-through decoration-2 text-muted-foreground">
+            {children}
+          </span>
+          <InactiveIcon />
+        </span>
+      );
+    }
     return children;
   }
 
@@ -118,7 +141,16 @@ export function UserHoverLink({
         onMouseLeave={() => setTooltipState(null)}
         onBlur={() => setTooltipState(null)}
       >
-        <span>{children}</span>
+        <span
+          className={
+            isInactive(user)
+              ? "line-through decoration-2 text-muted-foreground"
+              : undefined
+          }
+        >
+          {children}
+        </span>
+        {isInactive(user) && <InactiveIcon />}
         {user.type && (
           <UserRoleBadge
             type={user.type}
@@ -155,7 +187,16 @@ export function UserHoverLink({
               </div>
               <div className="flex flex-col min-w-0">
                 <div className="text-sm font-semibold truncate flex items-center gap-1.5">
-                  {tooltipName}
+                  <span
+                    className={
+                      isInactive(user)
+                        ? "line-through decoration-2 text-muted-foreground"
+                        : undefined
+                    }
+                  >
+                    {tooltipName}
+                  </span>
+                  {isInactive(user) && <InactiveIcon />}
                   {user.type && (
                     <UserRoleBadge
                       type={user.type}
@@ -196,7 +237,16 @@ export function UserReferenceList({ users }: UserCollectionProps) {
             </UserHoverLink>
           ) : (
             <span className="font-medium">
-              {user.displayName || user.username}
+              <span
+                className={
+                  isInactive(user)
+                    ? "line-through decoration-2 text-muted-foreground"
+                    : undefined
+                }
+              >
+                {user.displayName || user.username}
+              </span>
+              {isInactive(user) && <InactiveIcon />}
             </span>
           )}
           {user.email && (
@@ -228,7 +278,18 @@ export function UserReferenceInlineList({ users }: UserCollectionProps) {
               {user.username || user.displayName}
             </UserHoverLink>
           ) : (
-            user.username || user.displayName
+            <>
+              <span
+                className={
+                  isInactive(user)
+                    ? "line-through decoration-2 text-muted-foreground"
+                    : undefined
+                }
+              >
+                {user.username || user.displayName}
+              </span>
+              {isInactive(user) && <InactiveIcon />}
+            </>
           )}
           {index < users.length - 1 ? ", " : ""}
         </span>
@@ -268,7 +329,16 @@ export function SelectableUserPicker({
               </div>
               <div className="flex flex-col min-w-0">
                 <span className="text-sm font-medium leading-none">
-                  {user.displayName || user.username}
+                  <span
+                    className={
+                      isInactive(user)
+                        ? "line-through decoration-2 text-muted-foreground"
+                        : undefined
+                    }
+                  >
+                    {user.displayName || user.username}
+                  </span>
+                  {isInactive(user) && <InactiveIcon />}
                 </span>
                 <span className="text-xs text-muted-foreground mt-1 truncate">
                   {user.email}
@@ -292,7 +362,16 @@ export function SelectableUserSummary({ users }: UserCollectionProps) {
       {users.map((user) => (
         <li key={user.id} className="text-sm text-muted-foreground">
           <span className="text-foreground font-medium">
-            {user.displayName || user.username}
+            <span
+              className={
+                isInactive(user)
+                  ? "line-through decoration-2 text-muted-foreground"
+                  : undefined
+              }
+            >
+              {user.displayName || user.username}
+            </span>
+            {isInactive(user) && <InactiveIcon />}
           </span>
           {user.email ? ` (${user.email})` : ""}
         </li>
@@ -314,7 +393,16 @@ export function OwnerUserList({ users }: UserCollectionProps) {
             className="text-primary hover:underline text-sm font-medium flex items-center space-x-2"
             href={user.profilePath}
           >
-            {user.displayName || user.username}
+            <span
+              className={
+                isInactive(user)
+                  ? "line-through decoration-2 text-muted-foreground"
+                  : undefined
+              }
+            >
+              {user.displayName || user.username}
+            </span>
+            {isInactive(user) && <InactiveIcon />}
           </a>
         </li>
       ))}

--- a/src/frontend/src/pages/DirectoryUserDetailPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserDetailPage.tsx
@@ -6,6 +6,7 @@
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
 
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import DataState from "../components/common/DataState";
 import PageHeader from "../components/layout/PageHeader";
@@ -40,18 +41,86 @@ interface DirectoryUserDetailPageProps extends SessionPageProps {
   backFallback: string;
 }
 
+function resolveActiveUrl(
+  apiBase: string,
+  id: string,
+  role?: string,
+): string | null {
+  if (apiBase.startsWith("/api/admin/users")) {
+    return `/api/admin/users/${id}/active`;
+  }
+  if (apiBase.startsWith("/api/support")) {
+    return `/api/support/users/${id}/active`;
+  }
+  if (apiBase.startsWith("/api/tam")) {
+    return `/api/tam/users/${id}/active`;
+  }
+  if (apiBase.startsWith("/api/superuser")) {
+    return `/api/superuser/users/${id}/active`;
+  }
+  // TAM's user list (TamUserApiResource list) links to the shared
+  // /user/user-profiles/:id route, not a TAM-specific detail route.
+  // Map it to the TAM toggle endpoint, but only for TAM viewers —
+  // regular "user" role viewers of the same apiBase must not get a toggle.
+  if (apiBase.startsWith("/api/user/user-profiles") && role === "tam") {
+    return `/api/tam/users/${id}/active`;
+  }
+  return null;
+}
+
 export default function DirectoryUserDetailPage({
   apiBase,
   backFallback,
+  sessionState,
 }: DirectoryUserDetailPageProps) {
   const navigate = useNavigate();
   const { id } = useParams();
+  const [reloadKey, setReloadKey] = useState(0);
 
   const detailState = useJson<DirectoryUserDetail>(
-    id ? `${apiBase}/${id}` : null,
+    id ? `${apiBase}/${id}${reloadKey ? `?t=${reloadKey}` : ""}` : null,
   );
   const detail = detailState.data;
   const submissionGuard = useSubmissionGuard();
+
+  const activeUrl = id
+    ? resolveActiveUrl(apiBase, id, sessionState.data?.role)
+    : null;
+  const isAdminView = apiBase.startsWith("/api/admin/users");
+  const sessionUsername = sessionState.data?.username;
+  const isSelf =
+    Boolean(sessionUsername) &&
+    Boolean(detail?.username) &&
+    sessionUsername!.toLowerCase() === detail!.username!.toLowerCase();
+  const isToggleableType =
+    isAdminView ||
+    (detail?.type != null &&
+      ["user", "external"].includes(detail.type.toLowerCase()));
+  const showActiveToggle =
+    activeUrl !== null &&
+    detail?.active !== undefined &&
+    !isSelf &&
+    isToggleableType;
+
+  const toggleActive = async () => {
+    if (!activeUrl || detail?.active === undefined) {
+      return;
+    }
+    if (!submissionGuard.tryEnter()) {
+      return;
+    }
+    try {
+      await postForm(activeUrl, [["active", !detail.active]]);
+      toast.success(detail.active ? "User deactivated." : "User activated.");
+      setReloadKey((key) => key + 1);
+    } catch (error: unknown) {
+      toast.error(
+        error instanceof Error ? error.message : "Unable to update status.",
+      );
+    } finally {
+      submissionGuard.exit();
+    }
+  };
 
   const deleteUser = async () => {
     if (!detail?.deletePath || !submissionGuard.tryEnter()) {
@@ -144,6 +213,16 @@ export default function DirectoryUserDetailPage({
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
+                )}
+                {showActiveToggle && (
+                  <Button
+                    type="button"
+                    variant={detail.active ? "outline" : "default"}
+                    className={detail.deletePath ? undefined : "ml-auto"}
+                    onClick={toggleActive}
+                  >
+                    {detail.active ? "Deactivate" : "Activate"}
+                  </Button>
                 )}
                 {detail.editPath && (
                   <Button asChild>

--- a/src/frontend/src/pages/DirectoryUserFormPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserFormPage.tsx
@@ -17,6 +17,7 @@ import useJson from "../hooks/useJson";
 import useSubmissionGuard from "../hooks/useSubmissionGuard";
 import useNumberShortcuts from "../hooks/useNumberShortcuts";
 import { postForm } from "../utils/api";
+import type { FormEntryValue } from "../utils/api";
 import { createDirectoryUserFormState } from "../utils/forms";
 import { toQueryString } from "../utils/formatting";
 import { resolveClientPath, resolvePostRedirectPath } from "../utils/routing";
@@ -29,6 +30,7 @@ import type {
 } from "../types/domain";
 import type { DirectoryUserFormState } from "../utils/forms";
 import { Button } from "../components/ui/button";
+import { Switch } from "../components/ui/switch";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -79,6 +81,10 @@ export default function DirectoryUserFormPage({
   const allowUnassignedCompany = bootstrapBase === "/api/admin/users/bootstrap";
   const isAdminCreate =
     !isEdit && bootstrapBase === "/api/admin/users/bootstrap";
+  const showActiveField =
+    isEdit &&
+    (bootstrapBase === "/api/admin/users/bootstrap" ||
+      bootstrapBase.endsWith("/externals/bootstrap"));
   const [formState, setFormState] = useState<DirectoryUserFormState | null>(
     null,
   );
@@ -192,6 +198,9 @@ export default function DirectoryUserFormPage({
         ["type", formState.type],
         ["companyId", formState.companyId],
         ["password", formState.password],
+        ...(showActiveField
+          ? [["active", formState.active] as [string, FormEntryValue]]
+          : []),
       ]);
       toast.success(
         isEdit ? "User updated successfully." : "User created successfully.",
@@ -486,6 +495,28 @@ export default function DirectoryUserFormPage({
                     </SelectContent>
                   </Select>
                 </Field>
+                {showActiveField && (
+                  <Field>
+                    <FieldLabel className="text-[var(--color-header-bg)]">
+                      Active
+                    </FieldLabel>
+                    <div className="flex items-center gap-3">
+                      <Switch
+                        checked={formState.active}
+                        onCheckedChange={(checked) =>
+                          updateFormState("active", checked)
+                        }
+                        aria-label="Active status"
+                      />
+                      <span className="text-sm text-muted-foreground">
+                        {formState.active ? "Active" : "Inactive"}
+                      </span>
+                    </div>
+                    <FieldDescription>
+                      Inactive users cannot sign in.
+                    </FieldDescription>
+                  </Field>
+                )}
                 {formState.type === "external" && (
                   <div className="sm:col-span-2">
                     <p className="text-sm text-muted-foreground bg-muted/50 p-4 rounded-md border border-border">

--- a/src/frontend/src/pages/DirectoryUsersPage.tsx
+++ b/src/frontend/src/pages/DirectoryUsersPage.tsx
@@ -25,7 +25,11 @@ import type {
 import { Card, CardHeader } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
-import { UserRoleBadge } from "../components/users/UserComponents";
+import {
+  InactiveIcon,
+  isInactive,
+  UserRoleBadge,
+} from "../components/users/UserComponents";
 import {
   Select,
   SelectContent,
@@ -190,19 +194,34 @@ export default function DirectoryUsersPage({
                           className="text-[var(--color-header-bg)] hover:underline hover:opacity-80"
                           href={user.detailPath}
                         >
-                          {user.displayName ||
-                            user.fullName ||
-                            user.username ||
-                            "User"}
+                          <span
+                            className={
+                              isInactive(user)
+                                ? "line-through decoration-2 text-muted-foreground"
+                                : undefined
+                            }
+                          >
+                            {user.displayName ||
+                              user.fullName ||
+                              user.username ||
+                              "User"}
+                          </span>
                         </SmartLink>
                       ) : (
-                        <span>
+                        <span
+                          className={
+                            isInactive(user)
+                              ? "line-through decoration-2 text-muted-foreground"
+                              : undefined
+                          }
+                        >
                           {user.displayName ||
                             user.fullName ||
                             user.username ||
                             "User"}
                         </span>
                       )}
+                      {isInactive(user) && <InactiveIcon />}
                       {user.type && (
                         <UserRoleBadge
                           type={user.type}

--- a/src/frontend/src/pages/SupportTicketDetailPage.tsx
+++ b/src/frontend/src/pages/SupportTicketDetailPage.tsx
@@ -16,6 +16,8 @@ import MarkdownContent from "../components/markdown/MarkdownContent";
 import LexicalEditor from "../components/editor/LexicalEditor";
 import MessageVisibilityField from "../components/tickets/MessageVisibilityField";
 import {
+  InactiveIcon,
+  isInactive,
   UserHoverLink,
   UserReferenceInlineList,
 } from "../components/users/UserComponents";
@@ -326,7 +328,16 @@ function ActivityTimeline({ events }: { events: EventEntry[] }) {
               </div>
               <div className="text-sm rounded-md border border-border/40 bg-card/50 p-3 shadow-sm inline-block">
                 <span className="font-semibold text-foreground">
-                  {authorLabel}
+                  <span
+                    className={
+                      event.user && isInactive(event.user)
+                        ? "line-through decoration-2 text-muted-foreground"
+                        : undefined
+                    }
+                  >
+                    {authorLabel}
+                  </span>
+                  {event.user && isInactive(event.user) && <InactiveIcon />}
                 </span>{" "}
                 <span className="text-muted-foreground">triggered action:</span>{" "}
                 <span className="font-medium text-foreground lowercase">

--- a/src/frontend/src/types/domain/users.ts
+++ b/src/frontend/src/types/domain/users.ts
@@ -30,6 +30,7 @@ export interface UserReference extends NamedEntity {
   phoneExtension?: string;
   type?: string;
   typeLabel?: string;
+  active?: boolean;
   companyId?: Id;
   countryId?: Id;
   timezoneId?: Id;
@@ -113,6 +114,7 @@ export interface DirectoryUserBootstrap {
     timezoneId?: Id;
     type?: string;
     companyId?: Id;
+    active?: boolean;
   };
   countries?: CountryOption[];
   timezones?: TimezoneOption[];

--- a/src/frontend/src/utils/forms.ts
+++ b/src/frontend/src/utils/forms.ts
@@ -26,6 +26,7 @@ export interface DirectoryUserFormState {
   companyId: string;
   password: string;
   verifyPassword: string;
+  active: boolean;
 }
 
 export function appendFormValue(
@@ -108,5 +109,6 @@ export function createDirectoryUserFormState(
         : "",
     password: "",
     verifyPassword: "",
+    active: bootstrap?.user?.active !== false,
   };
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>User: Inactive (#156)</h1>
<h2>Summary</h2>
<p>Users can now be marked inactive instead of deleted: inactive users can't log in, existing sessions are invalidated, and their name renders with a strike-through plus a <code>badge-off</code> icon everywhere it appears. Their history (messages, tickets, events) is preserved, not hidden or deleted.</p>
<h2>Behavior</h2>
<p><strong>What "inactive" means:</strong></p>
<ul>
<li>Login rejected with the same "Invalid credentials" response as a wrong password.</li>
<li>Active sessions killed on the next request.</li>
<li>Display name shown with strike-through + a "Inactive user" icon.</li>
<li>Still fully visible in history — never hidden or removed.</li>
</ul>
<p><strong>Who can toggle it, and within what scope:</strong></p>

Role | Target types | Company scope
-- | -- | --
Admin | any type | any company
Support | user/external only | any company
TAM | user/external only | assigned companies only
Superuser | user/external only | own company only


<p><strong>Guards on all four toggle endpoints:</strong></p>
<ul>
<li>Missing <code>active</code> param → 400</li>
<li>Self-toggle → 400</li>
<li>Non-admin targeting a privileged account (admin/support/tam/superuser) → 404</li>
<li>TAM/Superuser targeting a user outside their scope → 404</li>
<li>Every toggle is audit-logged</li>
</ul>
<h2>Backend</h2>
<ul>
<li><code>model/User.java</code> — new <code>active</code> boolean column, default <code>true</code>.</li>
<li><code>util/AuthHelper.java</code> + <code>resource/AuthResource.java</code> — session drop + login rejection for inactive accounts.</li>
<li><code>resource/UserDirectoryApiModels.java</code> — <code>active</code> added to <code>UserReference</code>, <code>UserFormData</code>, <code>UserDetailResponse</code>, and the ticket-facing <code>UserReference</code> DTOs (<code>SupportTicketApiResource</code>, <code>UserTicketApiResource</code>, <code>SuperuserTicketApiResource</code>), plus <code>UserViewApiResource</code> and <code>ExternalUserApiResource</code> detail responses.</li>
<li>New toggle endpoints: <code>AdminUserApiResource</code>, <code>SupportUserApiResource</code>, <code>TamUserApiResource</code>, <code>SuperuserDirectoryApiResource</code> — all <code>@POST</code>, form-encoded, transactional.</li>
<li><code>UserResource.updateAdminUser</code> and <code>ExternalUserResource.updateExternalUser</code> also accept <code>active</code> via their existing form-update flow, with the same self-toggle guard.</li>
</ul>
<h2>Frontend</h2>
<ul>
<li><code>types/domain/users.ts</code>, <code>utils/forms.ts</code> — <code>active</code> added to the relevant types/form state.</li>
<li><code>components/users/UserComponents.tsx</code> — shared <code>isInactive()</code> + inactive icon, applied across every place a user reference renders (hover link, lists, picker, summary, owner list).</li>
<li><code>pages/DirectoryUserFormPage.tsx</code> — Active switch on the edit forms that support it (admin edit + externals edit).</li>
<li><code>pages/DirectoryUserDetailPage.tsx</code> — role-aware Activate/Deactivate button, hidden for one's own account and for non-toggleable types.</li>
<li><code>pages/DirectoryUsersPage.tsx</code> — directory list cards.</li>
<li><code>pages/SupportTicketDetailPage.tsx</code> — activity timeline entries.</li>
</ul>
<h2>Testing</h2>
<p>22 new backend tests, following the existing file-per-role convention:</p>
<ul>
<li>Per toggle endpoint: deactivate → verify → reactivate, self-toggle (400), missing param (400), type restriction (404), out-of-company (404).</li>
<li>Form-based update path, inactive login rejection, live session invalidation.</li>
<li>Guard correctness confirmed by mutation testing — each guard was temporarily removed and the corresponding test failed as expected, then guards were restored.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>