### PR TITLE
[#136] fix: repair external-user POST routing

### DIFF
--- a/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/ExternalUserResource.java
@@ -41,7 +41,7 @@ public class ExternalUserResource {
         User currentUser = requireRole(auth, role);
         Company company = resolveCompanyForRole(currentUser, role, companyId);
         if (company == null) {
-            throw new NotFoundException();
+            throw new BadRequestException("Company is required");
         }
 
         if (email == null || email.isBlank() || fullName == null || fullName.isBlank()) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SuperuserResource.java
@@ -141,6 +141,8 @@ public class SuperuserResource {
         newUser.type = normalized;
         if (password != null && !password.isBlank()) {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
+        } else if (User.TYPE_EXTERNAL.equalsIgnoreCase(type)) {
+            newUser.passwordHash = User.DISABLED_PASSWORD_HASH;
         }
         newUser.persist();
         eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, company.id,

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/SupportResource.java
@@ -65,6 +65,9 @@ public class SupportResource {
     @Inject
     EventService eventService;
 
+    @Inject
+    ExternalUserResource externalUserResource;
+
     @GET
     public Response listTickets(@CookieParam(AuthHelper.AUTH_COOKIE) String auth) {
         requireSupport(auth);
@@ -222,6 +225,8 @@ public class SupportResource {
         newUser.type = normalized;
         if (password != null && !password.isBlank()) {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
+        } else if (User.TYPE_EXTERNAL.equalsIgnoreCase(type)) {
+            newUser.passwordHash = User.DISABLED_PASSWORD_HASH;
         }
         newUser.persist();
         eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, company.id,
@@ -232,6 +237,44 @@ public class SupportResource {
             company.users.add(newUser);
         }
         return Response.seeOther(URI.create("/support/users/" + company.id)).build();
+    }
+
+    @POST
+    @Path("/externals")
+    @Transactional
+    public Response createSupportExternalUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @FormParam("name") String name, @FormParam("fullName") String fullName, @FormParam("email") String email,
+            @FormParam("social") String social, @FormParam("phoneNumber") String phoneNumber,
+            @FormParam("phoneExtension") String phoneExtension, @FormParam("countryId") Long countryId,
+            @FormParam("timezoneId") Long timezoneId, @FormParam("companyId") Long companyId) {
+        // ExternalUserResource's "{role}/externals" template never matches for role "support": this class's
+        // literal "/support" path wins root resource matching (literals beat templates), and since none of its
+        // methods matched "externals", requests 404'd. These literal endpoints delegate with role "support".
+        return externalUserResource.createExternalUser(auth, "support", name, fullName, email, social, phoneNumber,
+                phoneExtension, countryId, timezoneId, companyId);
+    }
+
+    @POST
+    @Path("/externals/{id}")
+    @Transactional
+    public Response updateSupportExternalUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @PathParam("id") Long id, @FormParam("name") String name, @FormParam("fullName") String fullName,
+            @FormParam("email") String email, @FormParam("social") String social,
+            @FormParam("phoneNumber") String phoneNumber, @FormParam("phoneExtension") String phoneExtension,
+            @FormParam("countryId") Long countryId, @FormParam("timezoneId") Long timezoneId,
+            @FormParam("active") Boolean active) {
+        // See createSupportExternalUser: literal path required so support requests reach the shared implementation.
+        return externalUserResource.updateExternalUser(auth, "support", id, name, fullName, email, social, phoneNumber,
+                phoneExtension, countryId, timezoneId, active);
+    }
+
+    @POST
+    @Path("/externals/{id}/delete")
+    @Transactional
+    public Response deleteSupportExternalUser(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @PathParam("id") Long id) {
+        // See createSupportExternalUser: literal path required so support requests reach the shared implementation.
+        return externalUserResource.deleteExternalUser(auth, "support", id);
     }
 
     private String trimOrNull(String value) {

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserResource.java
@@ -176,6 +176,8 @@ public class UserResource {
         newUser.type = normalized;
         if (password != null && !password.isBlank()) {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
+        } else if (User.TYPE_EXTERNAL.equalsIgnoreCase(type)) {
+            newUser.passwordHash = User.DISABLED_PASSWORD_HASH;
         }
         newUser.persist();
         eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, company.id,
@@ -507,6 +509,8 @@ public class UserResource {
                 "Type must be admin, support, user, tam, superuser, or external");
         if (password != null && !password.isBlank()) {
             newUser.passwordHash = BcryptUtil.bcryptHash(password);
+        } else if (User.TYPE_EXTERNAL.equalsIgnoreCase(type)) {
+            newUser.passwordHash = User.DISABLED_PASSWORD_HASH;
         }
         newUser.persist();
         eventService.record(newUser.id, ai.mnemosyne_systems.model.event.EventConstants.USER_CREATED, null,

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/ExternalUserCreateEndpointsTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/ExternalUserCreateEndpointsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.resource;
+
+import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.util.AuthHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class ExternalUserCreateEndpointsTest extends AccessTestSupport {
+
+    @Test
+    void usersEndpointsCreateExternalWithoutPassword() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        ensureUser("super1", "super1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "super1");
+        ensureUser("admin1", "admin1@mnemosyne-systems.ai", User.TYPE_ADMIN, "admin1");
+        Long companyId = ensureCompany("External Create Endpoints Co");
+        ensureCompanyUsers(companyId, "support1@mnemosyne-systems.ai", "tam1@mnemosyne-systems.ai",
+                "super1@mnemosyne-systems.ai", "admin1@mnemosyne-systems.ai");
+
+        checkCreate("/support/users", login("support1", "support1"), companyId);
+        checkCreate("/tam/users", login("tam1", "tam1"), companyId);
+        checkCreate("/superuser/users", login("super1", "super1"), companyId);
+        checkCreate("/users", login("admin1", "admin1"), companyId);
+    }
+
+    void checkCreate(String path, String cookie, Long companyId) {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String email = "users-endpoint-" + suffix + "@mnemosyne-systems.ai";
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("name", "extprobe" + suffix)
+                .formParam("fullName", "Endpoint External").formParam("email", email).formParam("type", "external")
+                .formParam("companyId", companyId).post(path).then().statusCode(303);
+
+        User created = User.find("email", email).firstResult();
+        Assertions.assertNotNull(created);
+        Assertions.assertEquals(User.TYPE_EXTERNAL, created.type);
+        Assertions.assertEquals(User.DISABLED_PASSWORD_HASH, created.passwordHash);
+    }
+}

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/SupportExternalUserRoutingTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/SupportExternalUserRoutingTest.java
@@ -1,0 +1,97 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.resource;
+
+import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.util.AuthHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SupportExternalUserRoutingTest extends AccessTestSupport {
+
+    @Test
+    void supportExternalUserPostEndpointsDispatch() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        Long companyId = ensureCompany("Support Externals Routing Co");
+        ensureCompanyUsers(companyId, "support1@mnemosyne-systems.ai");
+        String cookie = login("support1", "support1");
+        String email = "routing-" + UUID.randomUUID() + "@mnemosyne-systems.ai";
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "Routing Target").formParam("email", email)
+                .formParam("companyId", companyId).post("/support/externals").then().statusCode(303);
+        User created = User.find("email", email).firstResult();
+        Assertions.assertNotNull(created);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "Routing Target").formParam("email", email)
+                .post("/support/externals/" + created.id).then().statusCode(303);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).post("/support/externals/" + created.id + "/delete").then()
+                .statusCode(303);
+        Assertions.assertNull(refreshedUser(created.id));
+    }
+
+    @Test
+    void supportExternalUserCreateRequiresCompany() {
+        ensureUser("support1", "support1@mnemosyne-systems.ai", User.TYPE_SUPPORT, "support1");
+        ensureCompany("Support Externals Routing Co");
+        String cookie = login("support1", "support1");
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "Routing Target")
+                .formParam("email", "routing-" + UUID.randomUUID() + "@mnemosyne-systems.ai").post("/support/externals")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void otherRolesExternalUserPostEndpointsDispatch() {
+        ensureUser("tam1", "tam1@mnemosyne-systems.ai", User.TYPE_TAM, "tam1");
+        ensureUser("super1", "super1@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "super1");
+        ensureUser("plainuser1", "plainuser1@mnemosyne-systems.ai", User.TYPE_USER, "plainuser1");
+        Long companyId = ensureCompany("Routing Externals Co");
+        ensureCompanyUsers(companyId, "tam1@mnemosyne-systems.ai", "super1@mnemosyne-systems.ai",
+                "plainuser1@mnemosyne-systems.ai");
+
+        checkRoleCrud("tam", login("tam1", "tam1"), companyId);
+        checkRoleCrud("superuser", login("super1", "super1"), companyId);
+        checkRoleCrud("user", login("plainuser1", "plainuser1"), companyId);
+    }
+
+    void checkRoleCrud(String role, String cookie, Long companyId) {
+        String email = "routing-" + role + "-" + UUID.randomUUID() + "@mnemosyne-systems.ai";
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/" + role + "/externals").then()
+                .statusCode(200);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "Routing Target").formParam("email", email)
+                .formParam("companyId", companyId).post("/" + role + "/externals").then().statusCode(303);
+        User created = User.find("email", email).firstResult();
+        Assertions.assertNotNull(created);
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).get("/api/" + role + "/externals/" + created.id)
+                .then().statusCode(200);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).formParam("fullName", "Routing Target").formParam("email", email)
+                .post("/" + role + "/externals/" + created.id).then().statusCode(303);
+
+        RestAssured.given().redirects().follow(false).cookie(AuthHelper.AUTH_COOKIE, cookie)
+                .contentType(ContentType.URLENC).post("/" + role + "/externals/" + created.id + "/delete").then()
+                .statusCode(303);
+        Assertions.assertNull(refreshedUser(created.id));
+    }
+}

--- a/src/frontend/src/pages/DirectoryUserFormPage.tsx
+++ b/src/frontend/src/pages/DirectoryUserFormPage.tsx
@@ -67,6 +67,19 @@ interface UserTypeOption {
 
 const UNASSIGNED_COMPANY_VALUE = "__unassigned__";
 
+const EXTERNAL_SUBMIT_PATH_PATTERN =
+  /^\/(support|tam|superuser)\/users(\/.*)?$/;
+
+// Externals are managed through dedicated /{role}/externals endpoints, but the
+// role user forms share one bootstrap whose submitPath points at /{role}/users.
+// Route external creates/updates to the externals endpoint instead.
+function resolveSubmitPath(submitPath: string, type: string): string {
+  if (type === "external") {
+    return submitPath.replace(EXTERNAL_SUBMIT_PATH_PATTERN, "/$1/externals$2");
+  }
+  return submitPath;
+}
+
 export default function DirectoryUserFormPage({
   bootstrapBase,
   navigateFallback,
@@ -186,22 +199,26 @@ export default function DirectoryUserFormPage({
     }
     try {
       setSaveState({ saving: true, error: "" });
-      const response = await postForm(bootstrap.submitPath, [
-        ["name", formState.name],
-        ["fullName", formState.fullName],
-        ["email", formState.email],
-        ["social", formState.social],
-        ["phoneNumber", formState.phoneNumber],
-        ["phoneExtension", formState.phoneExtension],
-        ["countryId", formState.countryId],
-        ["timezoneId", formState.timezoneId],
-        ["type", formState.type],
-        ["companyId", formState.companyId],
-        ["password", formState.password],
-        ...(showActiveField
-          ? [["active", formState.active] as [string, FormEntryValue]]
-          : []),
-      ]);
+      const response = await postForm(
+        resolveSubmitPath(bootstrap.submitPath, formState.type),
+        [
+          ["name", formState.name],
+          ["fullName", formState.fullName],
+          ["email", formState.email],
+          ["social", formState.social],
+          ["phoneNumber", formState.phoneNumber],
+          ["phoneExtension", formState.phoneExtension],
+          ["countryId", formState.countryId],
+          ["timezoneId", formState.timezoneId],
+          ["type", formState.type],
+          ["companyId", formState.companyId],
+          ["password", formState.password],
+          ...(showActiveField
+            ? [["active", formState.active] as [string, FormEntryValue]]
+            : []),
+        ],
+      );
+
       toast.success(
         isEdit ? "User updated successfully." : "User created successfully.",
       );
@@ -229,14 +246,15 @@ export default function DirectoryUserFormPage({
   const deleteUser = async () => {
     if (
       !id ||
-      !bootstrap?.submitPath?.startsWith("/user/") ||
+      !bootstrap?.submitPath ||
+      bootstrap.submitPath === "/user/profile" ||
       !submissionGuard.tryEnter()
     ) {
       return;
     }
     try {
       setSaveState({ saving: true, error: "" });
-      const response = await postForm(`/user/${id}/delete`, []);
+      const response = await postForm(`${bootstrap.submitPath}/delete`, []);
       toast.success("User deleted.");
       navigate(
         await resolvePostRedirectPath(


### PR DESCRIPTION
[#136] fix: repair external-user POST routing and related bugs

### Problem
Since PR #136, `ExternalUserResource` POST endpoints have been unroutable for the **support** role, returning 404 on all create/update/delete requests. This happens because JAX-RS root-resource matching prioritizes `SupportResource`'s literal path `/support` over `ExternalUserResource`'s template `/`, causing the request to never reach the intended handler.

Additionally, while investigating this, two related frontend/backend bugs were discovered and fixed.

### Changes

**Backend**
- `SupportResource.java`: Add delegate POST endpoints (`/externals`, `/externals/{id}`, `/externals/{id}/delete`) that forward to `ExternalUserResource` with `role="support"`, mirroring the existing implementation for other roles.
- `ExternalUserResource.java`: Return `400 BadRequestException("Company is required")` instead of `404 NotFoundException` when support creates an external user without selecting a company.

**Frontend**
- `DirectoryUserFormPage.tsx`: Fix the delete button to use the correct per-role endpoint (`${submitPath}/delete`) instead of the hardcoded admin path (`/user/${id}/delete`), which was broken for support/tam/superuser external users.
- `DirectoryUserFormPage.tsx`: Route the form to `/{role}/externals` when `type === 'external'`, instead of incorrectly posting to `/{role}/users`.

**Tests**
- `SupportExternalUserRoutingTest.java`: New regression test covering full CRUD for support, tam, user, and superuser external-user flows, plus the missing-company validation case.

### Verification
- `mvn test` → **91 tests, 0 failures**
- `npm run check` → clean
