### PR TITLE
[#155] Add role-based user search

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,5 @@ Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Hamza Azeem <hamzaalsherif9@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Mohamed Hamed <alkmohamed40@gmail.com>
+Ahmed Maarouf <ahmedwael5775@gmail.com>
+

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -12,6 +12,7 @@ Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Hamza Azeem <hamzaalsherif9@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Mohamed Hamed <alkmohamed40@gmail.com>
+Ahmed Maarouf <ahmedwael5775@gmail.com>
 ```
 
 ## Committers

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserDirectoryApiModels.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserDirectoryApiModels.java
@@ -115,4 +115,10 @@ public final class UserDirectoryApiModels {
             default -> "User";
         };
     }
+
+    public record UserSuggestionResponse(List<UserSuggestion> items) {
+    }
+
+    public record UserSuggestion(Long id, String name, String title, String detailPath) {
+    }
 }

--- a/src/backend/main/java/ai/mnemosyne_systems/resource/UserSearchApiResource.java
+++ b/src/backend/main/java/ai/mnemosyne_systems/resource/UserSearchApiResource.java
@@ -1,0 +1,133 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.resource;
+
+import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.util.AuthHelper;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Path("/api/users")
+@Produces(MediaType.APPLICATION_JSON)
+@Blocking
+public class UserSearchApiResource {
+
+    @GET
+    @Path("/suggest")
+    @Transactional
+    public UserDirectoryApiModels.UserSuggestionResponse suggest(@CookieParam(AuthHelper.AUTH_COOKIE) String auth,
+            @QueryParam("q") @DefaultValue("") String q) {
+
+        User currentUser = requireUser(auth);
+
+        String needle = q == null ? "" : q.trim().toLowerCase(Locale.ROOT);
+
+        List<User> users = scopedUsers(currentUser);
+        List<UserDirectoryApiModels.UserSuggestion> matches = new ArrayList<>();
+
+        for (User user : users) {
+            if (user == null || user.id == null) {
+                continue;
+            }
+
+            boolean nameMatches = user.name != null && user.name.toLowerCase(Locale.ROOT).contains(needle);
+
+            boolean fullNameMatches = user.fullName != null && user.fullName.toLowerCase(Locale.ROOT).contains(needle);
+
+            boolean emailMatches = user.email != null && user.email.toLowerCase(Locale.ROOT).contains(needle);
+
+            if (needle.isEmpty() || nameMatches || fullNameMatches || emailMatches) {
+                matches.add(new UserDirectoryApiModels.UserSuggestion(user.id, user.getDisplayName(), user.email,
+                        detailPath(currentUser, user)));
+            }
+
+            if (matches.size() >= 6) {
+                break;
+            }
+        }
+
+        return new UserDirectoryApiModels.UserSuggestionResponse(matches);
+    }
+
+    private List<User> scopedUsers(User currentUser) {
+        if (User.TYPE_USER.equalsIgnoreCase(currentUser.type)
+                || User.TYPE_SUPERUSER.equalsIgnoreCase(currentUser.type)) {
+
+            return User
+                    .<User> find(
+                            "select distinct target " + "from Company c " + "join c.users member "
+                                    + "join c.users target " + "where member = ?1 " + "order by target.name, target.id",
+                            currentUser)
+                    .list();
+        }
+
+        return User.<User> list("order by lower(name), id");
+    }
+
+    private String detailPath(User currentUser, User targetUser) {
+        String requesterType = currentUser.type == null ? "" : currentUser.type.toLowerCase(Locale.ROOT);
+
+        String targetType = targetUser.type == null ? "" : targetUser.type.toLowerCase(Locale.ROOT);
+
+        if (User.TYPE_SUPPORT.equals(requesterType)) {
+            return switch (targetType) {
+                case User.TYPE_SUPPORT -> "/support/support-users/" + targetUser.id;
+                case User.TYPE_TAM -> "/support/tam-users/" + targetUser.id;
+                case User.TYPE_SUPERUSER -> "/support/superuser-users/" + targetUser.id;
+                case User.TYPE_EXTERNAL -> "/support/externals/" + targetUser.id;
+                default -> "/support/user-profiles/" + targetUser.id;
+            };
+        }
+
+        if (User.TYPE_SUPERUSER.equals(requesterType)) {
+            return switch (targetType) {
+                case User.TYPE_SUPPORT -> "/superuser/support-users/" + targetUser.id;
+                case User.TYPE_SUPERUSER -> "/superuser/superuser-users/" + targetUser.id;
+                case User.TYPE_EXTERNAL -> "/superuser/externals/" + targetUser.id;
+                default -> "/superuser/user-profiles/" + targetUser.id;
+            };
+        }
+
+        if (User.TYPE_ADMIN.equals(requesterType)) {
+            return "/users/" + targetUser.id;
+        }
+
+        if (User.TYPE_TAM.equals(requesterType) && User.TYPE_EXTERNAL.equals(targetType)) {
+            return "/tam/externals/" + targetUser.id;
+        }
+
+        return switch (targetType) {
+            case User.TYPE_SUPPORT -> "/user/support-users/" + targetUser.id;
+            case User.TYPE_TAM -> "/user/tam-users/" + targetUser.id;
+            case User.TYPE_SUPERUSER -> "/user/superuser-users/" + targetUser.id;
+            case User.TYPE_EXTERNAL -> "/user/externals/" + targetUser.id;
+            default -> "/user/user-profiles/" + targetUser.id;
+        };
+    }
+
+    private User requireUser(String auth) {
+        User user = AuthHelper.findUser(auth);
+        if (user == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).build());
+        }
+        return user;
+    }
+}

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/AccessTestSupport.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/AccessTestSupport.java
@@ -83,6 +83,13 @@ abstract class AccessTestSupport {
     }
 
     @Transactional
+    void setUserFullName(String email, String fullName) {
+        User user = User.find("email", email).firstResult();
+        Assertions.assertNotNull(user);
+        user.fullName = fullName;
+    }
+
+    @Transactional
     void setUserEmailFormat(String email, String emailFormat) {
         User user = User.find("email", email).firstResult();
         Assertions.assertNotNull(user);

--- a/src/backend/test/java/ai/mnemosyne_systems/resource/UserSearchApiResourceTest.java
+++ b/src/backend/test/java/ai/mnemosyne_systems/resource/UserSearchApiResourceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+package ai.mnemosyne_systems.resource;
+
+import ai.mnemosyne_systems.model.User;
+import ai.mnemosyne_systems.util.AuthHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class UserSearchApiResourceTest extends AccessTestSupport {
+
+    @Test
+    void userSearchIsScopedByRole() {
+        ensureUser("search-user", "search-user@mnemosyne-systems.ai", User.TYPE_USER, "pass");
+        ensureUser("same-company-user", "same-company@mnemosyne-systems.ai", User.TYPE_USER, "pass");
+        ensureUser("other-company-user", "other-company@mnemosyne-systems.ai", User.TYPE_USER, "pass");
+        ensureUser("search-superuser", "search-superuser@mnemosyne-systems.ai", User.TYPE_SUPERUSER, "pass");
+        ensureUser("search-support", "search-support@mnemosyne-systems.ai", User.TYPE_SUPPORT, "pass");
+        ensureUser("search-tam", "search-tam@mnemosyne-systems.ai", User.TYPE_TAM, "pass");
+        ensureUser("search-admin", "search-admin@mnemosyne-systems.ai", User.TYPE_ADMIN, "pass");
+
+        Long companyId = ensureCompany("User Search Company");
+        Long otherCompanyId = ensureCompany("User Search Other Company");
+
+        ensureCompanyUsers(companyId, "search-user@mnemosyne-systems.ai", "same-company@mnemosyne-systems.ai",
+                "search-superuser@mnemosyne-systems.ai");
+
+        ensureCompanyUsers(otherCompanyId, "other-company@mnemosyne-systems.ai");
+
+        String userCookie = login("search-user", "pass");
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, userCookie).queryParam("q", "same-company")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.hasItem("same-company@mnemosyne-systems.ai"));
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, userCookie).queryParam("q", "other-company")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.not(Matchers.hasItem("other-company@mnemosyne-systems.ai")));
+
+        String superuserCookie = login("search-superuser", "pass");
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, superuserCookie).queryParam("q", "other-company")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.not(Matchers.hasItem("other-company@mnemosyne-systems.ai")));
+
+        String supportCookie = login("search-support", "pass");
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, supportCookie).queryParam("q", "other-company")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.hasItem("other-company@mnemosyne-systems.ai"));
+
+        String tamCookie = login("search-tam", "pass");
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, tamCookie).queryParam("q", "other-company")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.hasItem("other-company@mnemosyne-systems.ai"));
+
+        String adminCookie = login("search-admin", "pass");
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, adminCookie).queryParam("q", "other-company")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.hasItem("other-company@mnemosyne-systems.ai"));
+    }
+
+    @Test
+    void userSearchMatchesFullName() {
+        ensureUser("fullname-user", "fullname-user@mnemosyne-systems.ai", User.TYPE_USER, "pass");
+        ensureUser("search-user-fullname", "search-user-fullname@mnemosyne-systems.ai", User.TYPE_USER, "pass");
+
+        Long companyId = ensureCompany("User Search Full Name Company");
+
+        ensureCompanyUsers(companyId, "fullname-user@mnemosyne-systems.ai",
+                "search-user-fullname@mnemosyne-systems.ai");
+
+        setUserFullName("fullname-user@mnemosyne-systems.ai", "Technical Account Manager Full Name");
+
+        String cookie = login("search-user-fullname", "pass");
+
+        RestAssured.given().cookie(AuthHelper.AUTH_COOKIE, cookie).queryParam("q", "Technical Account Manager")
+                .get("/api/users/suggest").then().statusCode(200)
+                .body("items.title", Matchers.hasItem("fullname-user@mnemosyne-systems.ai"));
+    }
+}

--- a/src/frontend/src/components/layout/AuthenticatedHeader.tsx
+++ b/src/frontend/src/components/layout/AuthenticatedHeader.tsx
@@ -122,11 +122,19 @@ export default function AuthenticatedHeader({
       ? `/api/articles/suggest${toQueryString({ q: normalizedSearch })}`
       : null,
   );
+
+  const userSuggestionState = useJson<SuggestionResponse>(
+    shouldFetch
+      ? `/api/users/suggest${toQueryString({ q: normalizedSearch })}`
+      : null,
+  );
   const ticketSuggestions = ticketSuggestionState.data?.items || [];
   const articleSuggestions = articleSuggestionState.data?.items || [];
+  const userSuggestions = userSuggestionState.data?.items || [];
   const allSuggestions: SearchSuggestion[] = [
     ...ticketSuggestions,
     ...articleSuggestions,
+    ...userSuggestions,
   ].sort((a, b) =>
     (a.name || "").localeCompare(b.name || "", undefined, {
       sensitivity: "base",


### PR DESCRIPTION
[#155].

- Adds user search by name, full name, and email
- User and Superuser searches are limited to users in the same company
- TAM, Support, and Admin can search all users
- Integrates user results into the authenticated header search
- Adds backend tests for role-based scoping and full-name matching

Tests:
- mvn test
- npm run check